### PR TITLE
feat: Implement NVDEC decoding pipeline

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -10,10 +10,11 @@
                 "${workspaceFolder}/enet_x64-windows/include",
                 "${workspaceFolder}/gf-complete/include",
                 "${workspaceFolder}/Jerasure/include",
-
+                "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.5/include"
             ],
             "defines": [
                 "_DEBUG",
+                "USE_NVDEC",
                 "UNICODE",
                 "_UNICODE",
                 "NOMINMAX",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,32 @@ add_definitions(-DUNICODE -D_UNICODE)
 # プリプロセッサ定義
 add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN)
 
+# NVIDIA Video Codec SDK の検索
+# 環境変数 CUDA_PATH が設定されていることを期待
+find_path(NVDEC_INCLUDE_DIR NvDec/nvcuvid.h
+    PATHS
+        "$ENV{CUDA_PATH}/include"
+        "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.5/include"
+    DOC "NVIDIA Video Decoder include path"
+)
+find_library(NVDEC_LIB nvcuvid
+    PATHS
+        "$ENV{CUDA_PATH}/lib/x64"
+        "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.5/lib/x64"
+    DOC "NVIDIA Video Decoder library"
+)
+
+if(NOT NVDEC_INCLUDE_DIR OR NOT NVDEC_LIB)
+    message(WARNING "NVIDIA Video Codec SDK not found. NVDEC functionality will be disabled.")
+else()
+    message(STATUS "Found NVIDIA Video Codec SDK:")
+    message(STATUS "  Include Dir: ${NVDEC_INCLUDE_DIR}")
+    message(STATUS "  Library: ${NVDEC_LIB}")
+    # プリプロセッサ定義に USE_NVDEC を追加
+    add_definitions(-DUSE_NVDEC)
+endif()
+
+
 # インクルードディレクトリ
 include_directories(
     ${CMAKE_SOURCE_DIR}
@@ -29,6 +55,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/enet_x64-windows/include
     ${CMAKE_SOURCE_DIR}/gf-complete/include
     ${CMAKE_SOURCE_DIR}/Jerasure/include
+    ${NVDEC_INCLUDE_DIR}
 )
 
 # Jerasure and gf-complete libraries
@@ -48,6 +75,10 @@ set(SOURCES
     Globals.cpp
     ReedSolomon.cpp
 )
+if(NVDEC_LIB)
+    list(APPEND SOURCES Nvdec.cpp)
+endif()
+
 
 # ヘッダーファイル
 set(HEADERS
@@ -57,6 +88,9 @@ set(HEADERS
     Globals.h
     ReedSolomon.h
 )
+if(NVDEC_LIB)
+    list(APPEND HEADERS Nvdec.h)
+endif()
 
 # 実行ファイルを作成
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
@@ -90,9 +124,12 @@ target_link_libraries(${PROJECT_NAME}
     # Jerasure and gf-complete libraries
     ${JERASURE_LIB}
     ${GF_COMPLETE_LIB}
-    
-    
 )
+
+# NVDECライブラリのリンク (見つかった場合のみ)
+if(NVDEC_LIB)
+    target_link_libraries(${PROJECT_NAME} ${NVDEC_LIB})
+endif()
 
 
 

--- a/Globals.cpp
+++ b/Globals.cpp
@@ -25,3 +25,6 @@ HWND g_hWnd = nullptr;
 std::deque<ReadyGpuFrame> g_readyGpuFrameQueue;
 std::mutex g_readyGpuFrameQueueMutex;
 std::condition_variable g_readyGpuFrameQueueCV;
+
+// Definition for the H.264 frame queue to the decoder
+moodycamel::ConcurrentQueue<H264Frame> g_h264FrameQueue;

--- a/Globals.h
+++ b/Globals.h
@@ -15,14 +15,26 @@
 #include <iostream>
 #include <iomanip>
 #include <condition_variable>
+#include "concurrentqueue/concurrentqueue.h"
 
 #define SIZE_PACKET_SIZE 258
+
+// Struct to hold data for the NVDEC decoder
+struct H264Frame {
+    uint64_t timestamp;
+    uint32_t frameNumber;
+    std::vector<uint8_t> frameData;
+};
+
+// Queue for passing H.264 frames from FEC workers to NVDEC workers
+extern moodycamel::ConcurrentQueue<H264Frame> g_h264FrameQueue;
 
 extern std::atomic<int> currentResolutionWidth;
 extern std::atomic<int> currentResolutionHeight;
 extern HWND g_hWnd;
 // D3D12 Globals (defined in window.cpp)
 extern Microsoft::WRL::ComPtr<ID3D12Device> g_d3d12Device;
+extern Microsoft::WRL::ComPtr<ID3D12CommandQueue> g_d3d12CommandQueue;
 
 extern const int RS_K;
 extern const int RS_M;

--- a/Nvdec.cpp
+++ b/Nvdec.cpp
@@ -1,0 +1,126 @@
+#include "Nvdec.h"
+#include "DebugLog.h"
+
+#ifdef USE_NVDEC
+
+#include <cuda.h>
+
+NvdecDecoder::NvdecDecoder() {
+    // Constructor
+}
+
+NvdecDecoder::~NvdecDecoder() {
+    Cleanup();
+}
+
+void NvdecDecoder::Cleanup() {
+    // Implementation for releasing resources
+    if (m_cuDecoder) {
+        cuvidDestroyDecoder(m_cuDecoder);
+        m_cuDecoder = nullptr;
+    }
+
+    if (m_cuContext) {
+        cuCtxDestroy(m_cuContext);
+        m_cuContext = nullptr;
+    }
+}
+
+bool NvdecDecoder::Init(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue) {
+    if (!pDevice || !pCommandQueue) {
+        DebugLog(L"NvdecDecoder::Init: Invalid D3D12 device or command queue.");
+        return false;
+    }
+
+    m_pD3D12Device = pDevice;
+    m_pCommandQueue = pCommandQueue;
+
+    // --- Initialize CUDA ---
+    CUresult cuResult = cuInit(0);
+    if (cuResult != CUDA_SUCCESS) {
+        DebugLog(L"NvdecDecoder::Init: cuInit failed. Error: " + std::to_wstring(cuResult));
+        return false;
+    }
+
+    // Find a CUDA-capable device
+    CUdevice cuDevice = 0; // Assuming the first device
+    cuResult = cuDeviceGet(&cuDevice, 0);
+    if (cuResult != CUDA_SUCCESS) {
+        DebugLog(L"NvdecDecoder::Init: cuDeviceGet failed. Error: " + std::to_wstring(cuResult));
+        return false;
+    }
+
+    // Create a CUDA context
+    cuResult = cuCtxCreate(&m_cuContext, 0, cuDevice);
+    if (cuResult != CUDA_SUCCESS) {
+        DebugLog(L"NvdecDecoder::Init: cuCtxCreate failed. Error: " + std::to_wstring(cuResult));
+        return false;
+    }
+
+    // --- Initialize the NVDEC decoder ---
+    CUVIDDECODECREATEINFO decode_create_info = { 0 };
+    decode_create_info.CodecType = cudaVideoCodec_H264;
+    decode_create_info.ulWidth = 1920; // Placeholder, will be determined from bitstream
+    decode_create_info.ulHeight = 1080; // Placeholder
+    decode_create_info.ulNumDecodeSurfaces = 20; // A pool of surfaces for decoding
+    decode_create_info.ChromaFormat = cudaVideoChromaFormat_420;
+    decode_create_info.OutputFormat = cudaVideoSurfaceFormat_NV12;
+    // Important: Use D3D12 device
+    decode_create_info.target_ext.d3d12.pD3D12Device = m_pD3D12Device.Get();
+    decode_create_info.target_ext.d3d12.pD3D12CommandQueue = m_pCommandQueue.Get();
+
+
+    cuResult = cuvidCreateDecoder(&m_cuDecoder, &decode_create_info);
+    if (cuResult != CUDA_SUCCESS) {
+        DebugLog(L"NvdecDecoder::Init: cuvidCreateDecoder failed. Error: " + std::to_wstring(cuResult));
+        Cleanup();
+        return false;
+    }
+
+    DebugLog(L"NvdecDecoder::Init: Successfully initialized.");
+    return true;
+}
+
+bool NvdecDecoder::Decode(const uint8_t* pData, size_t nSize, uint64_t timestamp) {
+    if (!m_cuDecoder) {
+        return false;
+    }
+
+    // This is a simplified decode call. The actual implementation is more complex
+    // and involves parsing and handling the bitstream correctly.
+    // For now, this is a placeholder.
+
+    CUVIDSOURCEDATAPACKET packet = { 0 };
+    packet.payload = pData;
+    packet.payload_size = nSize;
+    packet.flags = CUVID_PKT_TIMESTAMP;
+    packet.timestamp = timestamp;
+
+    CUresult cuResult = cuvidDecodePicture(m_cuDecoder, &packet);
+    if (cuResult != CUDA_SUCCESS) {
+        DebugLog(L"NvdecDecoder::Decode: cuvidDecodePicture failed. Error: " + std::to_wstring(cuResult));
+        return false;
+    }
+
+    return true;
+}
+
+bool NvdecDecoder::GetDecodedFrame(Microsoft::WRL::ComPtr<ID3D12Resource>& ppDecodedTexture, uint64_t& pTimestamp) {
+    if (!m_cuDecoder) {
+        return false;
+    }
+
+    // This function should map a decoded surface, get the D3D12 resource,
+    // and return it. This is a complex process involving synchronization.
+    // This is a placeholder for now.
+
+    CUVIDPARSERDISPINFO dispInfo = { 0 };
+    // The actual implementation would involve a callback mechanism (pfnDisplayPicture)
+    // that queues up dispInfo structs. This function would then dequeue them.
+    // For now, we can't implement this without the full callback structure.
+
+    // Placeholder: returning false as we don't have a frame yet.
+    return false;
+}
+
+#endif // USE_NVDEC

--- a/Nvdec.h
+++ b/Nvdec.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#ifdef USE_NVDEC
+
+#include <d3d12.h>
+#include <wrl/client.h>
+#include <vector>
+#include <cstdint>
+
+// Forward declarations for NVDEC types to avoid including the full header here if possible
+// However, for simplicity in this context, we will include the main header.
+#include "NvDec/nvcuvid.h"
+#include "NvDec/cuviddec.h"
+
+class NvdecDecoder {
+public:
+    NvdecDecoder();
+    ~NvdecDecoder();
+
+    // Initialize the decoder with the D3D12 device
+    bool Init(ID3D12Device* pDevice, ID3D12CommandQueue* pCommandQueue);
+
+    // Decode a single H.264 frame
+    bool Decode(const uint8_t* pData, size_t nSize, uint64_t timestamp);
+
+    // Get a completed frame from the decoder
+    bool GetDecodedFrame(Microsoft::WRL::ComPtr<ID3D12Resource>& ppDecodedTexture, uint64_t& pTimestamp);
+
+private:
+    // Internal helper functions and member variables will go here
+    void Cleanup();
+
+    Microsoft::WRL::ComPtr<ID3D12Device> m_pD3D12Device;
+    Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_pCommandQueue;
+
+    // CUDA/NVDEC specific members
+    CUcontext m_cuContext = nullptr;
+    CUvideodecoder m_cuDecoder = nullptr;
+
+    // ... more members for managing frame buffers, etc.
+};
+
+#endif // USE_NVDEC


### PR DESCRIPTION
This commit introduces the architectural pipeline for hardware-accelerated video decoding using the NVIDIA Video Codec SDK (NVDEC).

The key changes include:
- A new `NvdecWorkerThread` that processes H.264 video frames.
- A concurrent queue (`g_h264FrameQueue`) to pass H.264 data from the existing FEC (Forward Error Correction) threads to the new NVDEC threads.
- A new `NvdecDecoder` class to encapsulate the NVDEC API. NOTE: The implementation of this class is currently a placeholder and does not perform full decoding. It initializes the CUDA context and the decoder but the main decoding loop and frame retrieval logic needs to be completed.
- The rendering logic in `window.cpp` has been adapted to accept the NV12 D3D12 texture format that will be produced by NVDEC. It now creates two Shader Resource Views (for Y and UV planes) from the single NV12 texture.
- The build system (`CMakeLists.txt`) has been updated to find and link against the NVIDIA Codec SDK. The new functionality is guarded by the `USE_NVDEC` preprocessor flag, which is enabled if the SDK is found.

This provides the complete data flow from the network receiver to the renderer, allowing for a full implementation of the NVDEC logic to be integrated into the new `NvdecDecoder` class.