### PR TITLE
feat: Add elapsed time logging for frame decoding

### DIFF
--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -735,7 +735,10 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
         std::lock_guard<std::mutex> lock(g_readyGpuFrameQueueMutex);
         g_readyGpuFrameQueue.push_back(std::move(readyFrame));
         if(HandlePictureDisplayCount++ % 200 == 0) {
-            DebugLog(L"HandlePictureDisplay: Pushed Frame Enqueue Size " + std::to_wstring(g_readyGpuFrameQueue.size()));
+            std::wstringstream wss;
+            wss << L"HandlePictureDisplay: Pushed Frame Enqueue Size " << g_readyGpuFrameQueue.size()
+                << L", キューイング経過時間: " << readyFrame.rawpacket_to_render_time_ms << " ms";
+            DebugLog(wss.str());
         }
     }
     g_readyGpuFrameQueueCV.notify_one();


### PR DESCRIPTION
Adds a log message to output the elapsed time between when a frame is dequeued for decoding and when it is enqueued for rendering.

This helps in monitoring and debugging the performance of the video decoding pipeline. The log is in Japanese as requested and is sampled to avoid excessive output.