### PR TITLE
This change ensures the initial swap-chain resize uses the client are…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1248,12 +1248,12 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
     currentResolutionWidth  = tw;
     currentResolutionHeight = th;
 
-    // Enqueue an initial resize for the render thread (to align swap-chain)
-    g_pendingResize.w.store(tw, std::memory_order_relaxed);
-    g_pendingResize.h.store(th, std::memory_order_relaxed);
+    // Enqueue an initial resize for the render thread (swap-chain must match CLIENT size, not video)
+    g_pendingResize.w.store(cw, std::memory_order_relaxed);
+    g_pendingResize.h.store(ch, std::memory_order_relaxed);
     g_pendingResize.has.store(true, std::memory_order_release);
 
-    // Force-send to server now (single gate):
+    // Force-send to server now (single gate): advertise *video* size (tw x th), unchanged
     OnResolutionChanged_GatedSend(tw, th, /*force=*/true);
 
     // Initialize CUDA and NVDEC

--- a/window.cpp
+++ b/window.cpp
@@ -938,6 +938,11 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
     CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(g_rtvHeap->GetCPUDescriptorHandleForHeapStart(), g_currentFrameBufferIndex, g_rtvDescriptorSize);
     g_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
 
+    // >>> NEW: Ensure viewport/scissor initially cover the full backbuffer <<<
+    if (g_renderTargets[g_currentFrameBufferIndex]) {
+        SetViewportScissorToBackbuffer(g_commandList.Get(), g_renderTargets[g_currentFrameBufferIndex].Get());
+    }
+
     // Optional: clear to black so gutters are black (no blue flicker around the content)
     const float clearColor[4] = {0.f, 0.f, 0.f, 1.f};
     g_commandList->ClearRenderTargetView(rtvHandle, clearColor, 0, nullptr);


### PR DESCRIPTION
…a, making startup letterboxing consistent with post-resize behavior.

It also adds a default full-backbuffer viewport/scissor before clears to prevent stale rendering states.