### PR TITLE
Tune reorderer buffer to reduce latency

### DIFF
--- a/window.cpp
+++ b/window.cpp
@@ -349,7 +349,7 @@ void ClearReorderState()
 }
 
 // 調整パラメータ
-static constexpr size_t REORDER_MAX_BUFFER = 8; // これを超えたら妥協して前進
+static constexpr size_t REORDER_MAX_BUFFER = 3; // これを超えたら妥協して前進
 static constexpr int    REORDER_WAIT_MS    = 2; // N+1 を待つ最大時間（ms）
 static std::chrono::steady_clock::time_point g_lastReorderDecision = std::chrono::steady_clock::now();
 


### PR DESCRIPTION
Reduces the reorderer's maximum buffer size to lower potential latency.

The 'Client FEC End->RenderEnd' latency was occasionally high due to the frame reordering logic buffering for too long. This change reduces the `REORDER_MAX_BUFFER` from 8 to 3, causing the renderer to wait less for out-of-order frames and thus reducing the latency contribution from this stage.

The NVDEC pipeline was confirmed to be fully asynchronous using CUDA events, and timing calculations were verified as correct. No changes were needed in those areas.