### PR TITLE
Fix: C3861 'cuD3D12GetDevice' identifier not found

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -58,6 +58,7 @@ using namespace DebugLogAsync;
 #include "AppShutdown.h"
 #include <cuda.h>
 #include <cuda_runtime_api.h>
+#include <cudaD3D12.h>
 #include <d3dx12.h>
 #include <d3d12.h>
 


### PR DESCRIPTION
Added the required header <cudaD3D12.h> to main.cpp to resolve the C3861 compile error. This header provides the necessary declarations for CUDA and Direct3D 12 interoperability functions.