### PR TITLE
Fix: Add CUDA version check for cuDeviceGetByLuid

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1304,7 +1304,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
 
     // Try direct lookup by LUID (preferred)
     bool foundByLuid = false;
-#if defined(_WIN32)
+#if defined(_WIN32) && defined(CUDA_VERSION) && CUDA_VERSION >= 10010
     {
         CUdevice tmpDev = 0;
         r = cuDeviceGetByLuid(&tmpDev, dxgiLuidBytes, (unsigned int)sizeof(dxgiLuidBytes));


### PR DESCRIPTION
Conditionally compiles the call to `cuDeviceGetByLuid` to only when the CUDA Toolkit version is 10.1 or newer.

This resolves the C3861 compile error ('identifier not found') when building with older CUDA versions that do not support this function, while preserving the more efficient device lookup path for newer versions. The existing fallback mechanism will be used on older systems.