### PR TITLE
Adds a deadline-driven jitter buffer and configurable frames-in-flight.

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -132,6 +132,15 @@ struct ThreadConfig {
     int render = 1;
     int RS_K = 1;
     int RS_M = 1;
+
+    // ==== NEW (for jitter buffer & GPU pacing) ====
+    int server_hz;                 // e.g., 60
+    int reorder_wait_ms;           // derived from server_hz
+    size_t reorder_max_buffer;     // e.g., 2
+    unsigned int frames_in_flight; // 2 (double) or 3 (triple)
 };
+
+// Centralized runtime tuning. Implemented in main.cpp.
+ThreadConfig getOptimalThreadConfig();
 
 #endif


### PR DESCRIPTION
- The `getOptimalThreadConfig()` function in `main.cpp` now calculates a jitter buffer wait time based on a 60Hz server cadence.
- The reorder logic in `window.cpp` uses these new configuration values.
- The number of frames-in-flight is now configurable, defaulting to 3 (triple buffering) to reduce GPU fence waits. This is implemented by replacing hardcoded double-buffering logic with a configurable back buffer count.