### PR TITLE
Fix D3D12 device removal on Present during window resize

### DIFF
--- a/Globals.cpp
+++ b/Globals.cpp
@@ -38,6 +38,7 @@ std::atomic<bool> g_decode_worker_Running(true);
 std::atomic<bool> app_running_atomic(true);
 std::atomic<bool> g_isSizing{false};
 std::atomic<bool> g_forcePresentOnce{false};
+std::atomic<bool> g_deviceLost{false};
 std::atomic<bool> dumpH264ToFiles{false};
 
 // H264 Frame queue

--- a/Globals.h
+++ b/Globals.h
@@ -114,6 +114,7 @@ struct H264Frame {
 extern std::atomic<bool> app_running_atomic;
 extern std::atomic<bool> g_isSizing;
 extern std::atomic<bool> g_forcePresentOnce; // Present at least once even if no new decoded frame
+extern std::atomic<bool> g_deviceLost;
 
 // Global queues and synchronization for frame management
 extern moodycamel::ConcurrentQueue<std::vector<uint8_t>*> g_h264BufferPool;


### PR DESCRIPTION
Implements a robust device-loss handling and recovery mechanism to address `DXGI_ERROR_DEVICE_REMOVED` errors that occur during window resizing.

Key changes:
- A global atomic flag `g_deviceLost` is introduced to track the device state.
- `RenderFrame()` now detects `DXGI_ERROR_DEVICE_REMOVED` and `DXGI_ERROR_DEVICE_RESET` from `Present()`, sets the `g_deviceLost` flag, and returns early to prevent log spam.
- On subsequent frames, `RenderFrame()` checks the flag and invokes a new `HandleDeviceLost()` function if the device was lost.
- `HandleDeviceLost()` safely releases all D3D12 resources without waiting on the lost GPU, then calls `InitD3D()` to re-create the device, swap chain, and all related resources.
- After successful re-creation, fence values are reset to synchronize the renderer with the new resources, and a forced present is triggered to resume rendering smoothly.