### PR TITLE
Add an is_prime function for primality testing.

### DIFF
--- a/Globals.cpp
+++ b/Globals.cpp
@@ -38,6 +38,7 @@ std::atomic<bool> g_decode_worker_Running(true);
 std::atomic<bool> app_running_atomic(true);
 std::atomic<bool> g_isSizing{false};
 std::atomic<bool> g_forcePresentOnce{false};
+std::atomic<bool> g_deviceLost{false};
 std::atomic<bool> g_dumpH264ToFile{false};
 
 // H264 Frame queue

--- a/Globals.h
+++ b/Globals.h
@@ -114,11 +114,8 @@ struct H264Frame {
 extern std::atomic<bool> app_running_atomic;
 extern std::atomic<bool> g_isSizing;
 extern std::atomic<bool> g_forcePresentOnce; // Present at least once even if no new decoded frame
-<<<<<<< Updated upstream
 extern std::atomic<bool> g_deviceLost;
-=======
 extern std::atomic<bool> g_dumpH264ToFile;
->>>>>>> Stashed changes
 
 // Global queues and synchronization for frame management
 extern moodycamel::ConcurrentQueue<std::vector<uint8_t>*> g_h264BufferPool;


### PR DESCRIPTION
The new function uses the naive O(sqrt(n))-time primality testing method that correctly handles negative integers also. Unit tests are added for positive and negative inputs.