### PR TITLE
Fix D3D12 recovery spinner: correct DXGI adapter enumeration to inclu…

### DIFF
--- a/window.cpp
+++ b/window.cpp
@@ -1364,6 +1364,7 @@ void RenderFrame() {
             g_forcePresentOnce.store(true, std::memory_order_release);
         } else {
             DebugLog(L"RenderFrame: Device-loss recovery failed; will retry next frame.");
+            Sleep(50); // Modest backoff to prevent hot spinning on recovery failure.
             return;
         }
     }


### PR DESCRIPTION
…de index 0; add modest backoff after failed InitD3D; no layout/comment changes; no goto; do not touch MonitorSharedMemory().