### PR TITLE
Reduce client-side latency & CPU:

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1020,6 +1020,7 @@ void FecWorkerThread(int threadId) {
         ParsedShardInfo parsedInfo;
 
         if(g_parsedShardQueue.size_approx() == 0){
+            std::this_thread::sleep_for(EMPTY_QUEUE_WAIT_MS);
             continue;
         }
 

--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -346,7 +346,7 @@ bool FrameDecoder::createDecoder(CUVIDEOFORMAT* pVideoFormat) {
     // We will perform a crop manually during the cuMemcpy2D.
     m_videoDecoderCreateInfo.ulTargetWidth = pVideoFormat->coded_width;
     m_videoDecoderCreateInfo.ulTargetHeight = pVideoFormat->coded_height;
-    m_videoDecoderCreateInfo.ulNumOutputSurfaces = 8; // more headroom during resize/IDR
+    m_videoDecoderCreateInfo.ulNumOutputSurfaces = 12; // more headroom during resize/IDR
     m_videoDecoderCreateInfo.OutputFormat = cudaVideoSurfaceFormat_NV12;
 
     CUDA_CHECK(cuvidCreateDecoder(&m_hDecoder, &m_videoDecoderCreateInfo));

--- a/window.cpp
+++ b/window.cpp
@@ -350,7 +350,7 @@ void ClearReorderState()
 
 // 調整パラメータ
 static constexpr size_t REORDER_MAX_BUFFER = 8; // これを超えたら妥協して前進
-static constexpr int    REORDER_WAIT_MS    = 1; // N+1 を待つ最大時間（ms） (from 3ms)
+static constexpr int    REORDER_WAIT_MS    = 0; // N+1 を待つ最大時間（ms） (from 3ms)
 static std::chrono::steady_clock::time_point g_lastReorderDecision = std::chrono::steady_clock::now();
 
 // Rendering specific D3D12 globals


### PR DESCRIPTION
- FEC worker: sleep 1ms on empty queue
- NVDEC: ulNumOutputSurfaces=12
- Reorder: REORDER_WAIT_MS=0 (Keep logs/timing; no layout/comment changes; no goto; MonitorSharedMemory() untouched)