### PR TITLE
Add NVTX ranges for profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/enet_x64-windows/include
     ${CMAKE_SOURCE_DIR}/gf-complete/include
     ${CMAKE_SOURCE_DIR}/Jerasure/include
+    ${CMAKE_SOURCE_DIR}/third_party/nvtx/include
     "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9/include"
     "C:/Program Files/NVIDIA Corporation/Video_Codec_SDK_13.0.19/Interface"
 )
@@ -315,6 +316,7 @@ set(CPP_PROPERTIES_JSON_CONTENT "{
                 \"\${workspaceFolder}/enet_x64-windows/include\",
                 \"\${workspaceFolder}/gf-complete/include\",
                 \"\${workspaceFolder}/Jerasure/include\",
+                \"\${workspaceFolder}/third_party/nvtx/include\",
                 \"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9/include\",
                 \"C:/Program Files/NVIDIA Corporation/Video_Codec_SDK_13.0.19/Interface\"
             ],

--- a/main.cpp
+++ b/main.cpp
@@ -59,6 +59,7 @@ using namespace DebugLogAsync;
 #include <cuda_runtime_api.h>
 #include <d3dx12.h>
 #include <d3d12.h>
+#include <nvtx3/nvtx3.hpp>
 
 // === 新規：ネットワーク準備・解像度ペンディング管理 ===
 std::atomic<bool> g_networkReady{false};
@@ -1150,6 +1151,7 @@ ThreadConfig getOptimalThreadConfig(){
 }
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nCmdShow) {
+    nvtx3::scoped_range r("Initialization");
     // Enforce GPU policy first
     if (!EnforceGpuPolicyOrExit()) {
         return 0; // Exit early per policy

--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <nvtx3/nvtx3.hpp>
 
 // Use a single monotonic clock for all latency metrics.
 static inline uint64_t SteadyNowMs() noexcept {
@@ -749,6 +750,7 @@ void NvdecThread(int threadId) {
     while (g_decode_worker_Running) { // Use the same global running flag
         H264Frame frame;
         if (g_h264FrameQueue.try_dequeue(frame)) {
+            nvtx3::scoped_range r("CUDA Decode");
             frame.decode_start_ms = SteadyNowMs();
             g_frameDecoder->Decode(frame);
             if(DecoderCount++ % 200 == 0)DebugLog(L"NvdecThread: Dequeue Size " + std::to_wstring(g_h264FrameQueue.size_approx()));

--- a/third_party/nvtx/include/nvtx3/nvToolsExt.h
+++ b/third_party/nvtx/include/nvtx3/nvToolsExt.h
@@ -1,0 +1,1668 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+/** \file nvToolsExt.h
+ */
+
+/* ========================================================================= */
+/** \mainpage
+ * \tableofcontents
+ * \section INTRODUCTION Introduction
+ *
+ * The NVIDIA Tools Extension library is a set of functions that a
+ * developer can use to provide additional information to tools.
+ * The additional information is used by the tool to improve
+ * analysis and visualization of data.
+ *
+ * The library introduces close to zero overhead if no tool is
+ * attached to the application.  The overhead when a tool is
+ * attached is specific to the tool.
+ *
+ * \section INITIALIZATION Initialization
+ *
+ * Typically the tool's library that plugs into NVTX is indirectly
+ * loaded via environmental properties that are platform specific.
+ * For some platform or special cases, the user may be required
+ * to instead explicitly initialize instead though.   This can also
+ * be helpful to control when the API loads a tool's library instead
+ * of what would typically be the first function call to emit info.
+ * For these rare case, see \ref INITIALIZATION for additional information.
+ *
+ * \section MARKERS_AND_RANGES Markers and Ranges
+ *
+ * Markers and ranges are used to describe events at a specific time (markers)
+ * or over a time span (ranges) during the execution of the application
+ * respectively.
+ *
+ * \subsection MARKERS Markers
+ *
+ * Markers denote specific moments in time.
+ *
+ *
+ * See \ref DOMAINS and \ref EVENT_ATTRIBUTES for additional information on
+ * how to specify the domain.
+ *
+ * \subsection THREAD_RANGES Thread Ranges
+ *
+ * Thread ranges denote nested time ranges. Nesting is maintained per thread
+ * per domain and does not require any additional correlation mechanism. The
+ * duration of a thread range is defined by the corresponding pair of
+ * nvtxRangePush* to nvtxRangePop API calls.
+ *
+ * See \ref DOMAINS and \ref EVENT_ATTRIBUTES for additional information on
+ * how to specify the domain.
+ *
+ * \subsection PROCESS_RANGES Process Ranges
+ *
+ * Process ranges denote a time span that can expose arbitrary concurrency, as
+ * opposed to thread ranges that only support nesting. In addition the range
+ * start event can happen on a different thread than the end marker. For the
+ * correlation of a start/end pair an unique correlation ID is used that is
+ * returned from the start API call and needs to be passed into the end API
+ * call.
+ *
+ * \subsection EVENT_ATTRIBUTES Event Attributes
+ *
+ * \ref MARKERS_AND_RANGES can be annotated with various attributes to provide
+ * additional information for an event or to guide the tool's visualization of
+ * the data. Each of the attributes is optional and if left unused the
+ * attributes fall back to a default value. The attributes include:
+ * - color
+ * - category
+ *
+ * To specify any attribute other than the text message, the \ref
+ * EVENT_ATTRIBUTE_STRUCTURE "Event Attribute Structure" must be used.
+ *
+ * \section DOMAINS Domains
+ *
+ * Domains enable developers to scope annotations. By default all events and
+ * annotations are in the default domain. Additional domains can be registered.
+ * This allows developers to scope markers, ranges, and resources names to
+ * avoid conflicts.
+ *
+ * The function ::nvtxDomainCreateA or ::nvtxDomainCreateW is used to create
+ * a named domain.
+ *
+ * Each domain maintains its own
+ * - categories
+ * - thread range stacks
+ * - registered strings
+ *
+ * The function ::nvtxDomainDestroy marks the end of the domain. Destroying
+ * a domain unregisters and destroys all objects associated with it such as
+ * registered strings, resource objects, named categories, and started ranges.
+ *
+ * \section RESOURCE_NAMING Resource Naming
+ *
+ * This section covers calls that allow to annotate objects with user-provided
+ * names in order to allow for a better analysis of complex trace data. All of
+ * the functions take the handle or the ID of the object to name and the name.
+ * The functions can be called multiple times during the execution of an
+ * application, however, in that case it is implementation dependent which
+ * name will be reported by the tool.
+ *
+ * \subsection CATEGORY_NAMING Category Naming
+ *
+ * Some function in this library support associating an integer category
+ * to enable filtering and sorting.  The category naming functions allow
+ * the application to associate a user friendly name with the integer
+ * category.  Support for domains have been added in NVTX_VERSION_2 to
+ * avoid collisions when domains are developed independently.
+ *
+ * \subsection RESOURCE_OBJECTS Resource Objects
+ *
+ * Resource objects are a generic mechanism for attaching data to an application
+ * resource.  The identifier field makes the association to a pointer or handle,
+ * while the type field helps provide deeper understanding of the identifier as
+ * well as enabling differentiation in cases where handles generated by different
+ * APIs may collide.  The resource object may also have an associated message to
+ * associate with the application resource, enabling further annotation of this
+ * object and how it is used.
+ *
+ * The resource object was introduced in NVTX_VERSION_2 to supersede existing naming
+ * functions and allow the application resource identified by those functions to be
+ * associated to a domain.  The other naming functions are still supported for backward
+ * compatibility but will be associated only to the default domain.
+ *
+ * \subsection RESOURCE_NAMING_OS Resource Naming
+ *
+ * Some operating system resources creation APIs do not support providing a user friendly
+ * name, such as some OS thread creation APIs.  This API support resource naming though
+ * both through resource objects and functions following the pattern
+ * nvtxName[RESOURCE_TYPE][A|W](identifier, name).  Resource objects introduced in NVTX_VERSION 2
+ * supersede the other functions with a a more general method of assigning names to OS resources,
+ * along with associating them to domains too.  The older nvtxName* functions are only associated
+ * with the default domain.
+ * \section EXTENSIONS Optional Extensions
+ * Optional extensions will either appear within the existing sections the extend or appear
+ * in the "Related Pages" when they introduce new concepts.
+ */
+
+ /**
+ * Tools Extension API version
+ */
+#if defined(NVTX_VERSION) && NTX_VERSION < 3
+#error "Trying to #include NVTX version 3 in a source file where an older NVTX version has already been included.  If you are not directly using NVTX (the NVIDIA Tools Extension library), you are getting this error because libraries you are using have included different versions of NVTX.  Suggested solutions are: (1) reorder #includes so the newest NVTX version is included first, (2) avoid using the conflicting libraries in the same .c/.cpp file, or (3) update the library using the older NVTX version to use the newer version instead."
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+/* Header guard */
+#if !defined(NVTX_VERSION)
+#define NVTX_VERSION 3
+
+/* Platform-dependent defines:
+ *
+ * - NVTX_API - Calling conventions (only used on Windows, and only effects
+ *   32-bit x86 builds, i.e. callee pops stack instead of caller)
+ *
+ * - NVTX_DYNAMIC_EXPORT - Make function an exported entry point from a
+ *   dynamic library or shared object.
+ *
+ * - NVTX_EXPORT_UNMANGLED_FUNCTION_NAME - When used inside the body of a
+ *   function declared with NVTX_DYNAMIC_EXPORT, ensures the symbol exported
+ *   for the function is the exact string of the function's name as written
+ *   in the code.  Name-mangling or name-decoration is disabled.  Note that
+ *   on many platforms this is not necessary, since either the function name
+ *   is already exported verbatim, or the dynamic loader also checks for
+ *   functions with the mangling applied.  Forcing the exports to avoid any
+ *   mangling simplifies usage across platforms and from other languages.
+ */
+#if defined(_WIN32)
+
+#define NVTX_API __stdcall
+
+#if defined(_MSC_VER)
+#define NVTX_DYNAMIC_EXPORT __declspec(dllexport)
+#else
+#define NVTX_DYNAMIC_EXPORT __attribute__((visibility("default"))) __declspec(dllexport)
+#endif
+
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_ARM64EC))
+#define NVTX_EXPORT_UNMANGLED_FUNCTION_NAME _Pragma("comment(linker, \"/EXPORT:\" __FUNCTION__ \"=\" __FUNCDNAME__)")
+#else
+#define NVTX_EXPORT_UNMANGLED_FUNCTION_NAME
+#endif
+
+#else /* POSIX-like platform */
+
+#define NVTX_API
+
+#define NVTX_DYNAMIC_EXPORT __attribute__((visibility("default")))
+
+#define NVTX_EXPORT_UNMANGLED_FUNCTION_NAME
+
+#endif /* Platform-dependent defines */
+
+/* Compiler-dependent defines:
+ *
+ * - NVTX_INLINE_STATIC - Ensure function has internal linkage, and suggest
+ *   avoiding code-gen of the function.  Without this, function has external
+ *   linkage with a strong symbol, so linker expects only one definition.
+ */
+#if defined(_MSC_VER)
+
+#define NVTX_INLINE_STATIC __inline static
+
+#else /* GCC-like compiler */
+
+#if defined(__cplusplus) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
+#define NVTX_INLINE_STATIC inline static
+#else
+#define NVTX_INLINE_STATIC __inline__ static
+#endif
+
+#endif /* Compiler-dependent defines */
+
+#if !defined(NVTX_NULLPTR)
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define NVTX_NULLPTR nullptr
+#else
+#define NVTX_NULLPTR NULL
+#endif
+#endif
+
+#if defined(__cplusplus)
+#define NVTX_STATIC_CAST(type, value)      (static_cast<type>(value))
+#define NVTX_REINTERPRET_CAST(type, value) (reinterpret_cast<type>(value))
+#else
+#define NVTX_STATIC_CAST(type, value)      ((type)(value))
+#define NVTX_REINTERPRET_CAST(type, value) ((type)(value))
+#endif
+
+
+/* API linkage/export options:
+ *
+ * - By default, the NVTX API functions are declared as "inline", with the
+ *   implementations provided in the headers.  This allows multiple .c/.cpp
+ *   files in the same project to include NVTX headers without duplicate-
+ *   definition linker errors.  An optimizing compiler should inline these
+ *   implementations, ensuring that the overhead of making an NVTX call is as
+ *   low as possible, even without enabling link-time optimizations.
+ *
+ * - NVTX_NO_IMPL - Use when writing NVTX tools.  If this macro is defined,
+ *   the NVTX headers will provide all the typedefs, macros, and declarations
+ *   of API functions (not marked inline), but no function implementations.
+ *
+ * - NVTX_EXPORT_API - NVTX is normally used in C/C++ applications by simply
+ *   including the headers.  There is no need to link with a static library,
+ *   or to ship a dynamic library with the application (this was changed in
+ *   NVTX v3).  For other languages, it's not convenient to use a header-only
+ *   C library.  The best way to provide an idiomatic NVTX API for another
+ *   language is a .c file that includes the NVTX headers and implements
+ *   functions for that language using its native calling conventions and
+ *   datatypes -- this method can allow static linking to avoid depending on
+ *   a separate dynamic library.  Alternatively, other languages may support
+ *   using C calling conventions to directly call C functions exported from a
+ *   dynamic library.  To build such a library, write a .c file that defines
+ *   NVTX_EXPORT_API and includes any/all of the NVTX headers.  Compile this
+ *   file as a dynamic library, and the NVTX API functions from the included
+ *   headers will be exported with no name-mangling or decoration.  Defining
+ *   ABI-compatible NVTX struct and enum types in the other language is the
+ *   responsibility of the user of this dynamic library.
+ *
+ * Whichever of the above modes is chosen, the following macros are defined
+ * appropriately below to implement that mode.  These macros are only defined
+ * if not already defined by the user, so they may be overridden by users to
+ * handle advanced cases.
+ *
+ * - NVTX_DECLSPEC - Specify linkage for NVTX API functions.
+ *
+ * - NVTX_SET_NAME_MANGLING_OPTIONS - If necessary for the platform, will use
+ *   platform-dependent syntax for ensuring function name is exported with no
+ *   name-mangling or decoration.  Certain compiler and calling-convention
+ *   combinations will add name-mangling or decorations when exporting NVTX
+ *   function name symbols, which makes it much harder for other languages
+ *   to access these functions.  This macro must be used inside a function's
+ *   body because it uses built-in macros to get the current function's name.
+ */
+#if defined(NVTX_NO_IMPL)
+
+/* When omitting implementation, avoid declaring functions inline
+ * without definitions, since this causes compiler warnings. */
+#if !defined(NVTX_DECLSPEC)
+#define NVTX_DECLSPEC
+#endif
+#if !defined(NVTX_SET_NAME_MANGLING_OPTIONS)
+#define NVTX_SET_NAME_MANGLING_OPTIONS
+#endif
+
+#elif defined(NVTX_EXPORT_API)
+
+/* Add platform-dependent declaration syntax to ensure NVTX API functions are
+ * exported when compiling as a dynamic library/shared object, and ensure the
+ * exported names are not mangled/decorated. */
+#if !defined(NVTX_DECLSPEC)
+#define NVTX_DECLSPEC NVTX_DYNAMIC_EXPORT
+#endif
+#if !defined(NVTX_SET_NAME_MANGLING_OPTIONS)
+#define NVTX_SET_NAME_MANGLING_OPTIONS NVTX_EXPORT_UNMANGLED_FUNCTION_NAME
+#endif
+
+#else /* Normal NVTX usage */
+
+/* Functions definitions are provided, and functions are declared inline to
+ * avoid duplicate-definition linker errors when using multiple source files. */
+#if !defined(NVTX_DECLSPEC)
+#define NVTX_DECLSPEC NVTX_INLINE_STATIC
+#endif
+#if !defined(NVTX_SET_NAME_MANGLING_OPTIONS)
+#define NVTX_SET_NAME_MANGLING_OPTIONS
+#endif
+
+#endif
+
+/* Platform-dependent helpers for defining global variables in header files.
+ * Ensures the linker uses only one instance when multiple source files include
+ * the headers, avoiding duplicate-definition linker errors. */
+#include "nvtxDetail/nvtxLinkOnce.h"
+
+/* Macros for applying major-version-specific suffix to NVTX global symbols, so
+ * usage of different versions in different source files is supported without
+ * violating the one-definition rule. */
+#define NVTX_VERSIONED_IDENTIFIER_L3(NAME, VERSION) NAME##_v##VERSION
+#define NVTX_VERSIONED_IDENTIFIER_L2(NAME, VERSION) NVTX_VERSIONED_IDENTIFIER_L3(NAME, VERSION)
+#define NVTX_VERSIONED_IDENTIFIER(NAME) NVTX_VERSIONED_IDENTIFIER_L2(NAME, NVTX_VERSION)
+
+/**
+ * The NVTX library depends on stdint.h.  If the build tool chain in use
+ * does not include stdint.h, then define NVTX_STDINT_TYPES_ALREADY_DEFINED
+ * and define the following types:
+ * <ul>
+ *   <li>uint8_t
+ *   <li>int8_t
+ *   <li>uint16_t
+ *   <li>int16_t
+ *   <li>uint32_t
+ *   <li>int32_t
+ *   <li>uint64_t
+ *   <li>int64_t
+ *   <li>uintptr_t
+ *   <li>intptr_t
+ * </ul>
+ * Be sure to define NVTX_STDINT_TYPES_ALREADY_DEFINED if you are using your
+ * own definitions instead of stdint.h.
+ */
+#ifndef NVTX_STDINT_TYPES_ALREADY_DEFINED
+#include <stdint.h>
+#endif
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+* Result Codes used for the NVTX tool loader.
+*/
+#define NVTX_SUCCESS 0
+#define NVTX_FAIL 1
+#define NVTX_ERR_INIT_LOAD_PROPERTY 2
+#define NVTX_ERR_INIT_ACCESS_LIBRARY 3
+#define NVTX_ERR_INIT_LOAD_LIBRARY 4
+#define NVTX_ERR_INIT_MISSING_LIBRARY_ENTRY_POINT 5
+#define NVTX_ERR_INIT_FAILED_LIBRARY_ENTRY_POINT 6
+#define NVTX_ERR_NO_INJECTION_LIBRARY_AVAILABLE 7
+
+/**
+ * Size of the nvtxEventAttributes_t structure.
+ */
+#define NVTX_EVENT_ATTRIB_STRUCT_SIZE (NVTX_STATIC_CAST(uint16_t, sizeof(nvtxEventAttributes_t)))
+
+#define NVTX_NO_PUSH_POP_TRACKING (NVTX_STATIC_CAST(int, -2))
+
+typedef uint64_t nvtxRangeId_t;
+
+/* Forward declaration of opaque domain registration structure */
+struct nvtxDomainRegistration_st;
+typedef struct nvtxDomainRegistration_st nvtxDomainRegistration;
+
+/* \brief Domain Handle Structure.
+* \anchor DOMAIN_HANDLE_STRUCTURE
+*
+* This structure is opaque to the user and is used as a handle to reference
+* a domain.  This type is returned from tools when using the NVTX API to
+* create a domain.
+*
+*/
+typedef nvtxDomainRegistration* nvtxDomainHandle_t;
+
+/* Forward declaration of opaque string registration structure */
+struct nvtxStringRegistration_st;
+typedef struct nvtxStringRegistration_st nvtxStringRegistration;
+
+/* \brief Registered String Handle Structure.
+* \anchor REGISTERED_STRING_HANDLE_STRUCTURE
+*
+* This structure is opaque to the user and is used as a handle to reference
+* a registered string.  This type is returned from tools when using the NVTX
+* API to create a registered string.
+*
+*/
+typedef nvtxStringRegistration* nvtxStringHandle_t;
+
+/* ========================================================================= */
+/** \defgroup GENERAL General
+ * @{
+ */
+
+/** ---------------------------------------------------------------------------
+ * Color Types
+ * ------------------------------------------------------------------------- */
+typedef enum nvtxColorType_t
+{
+    NVTX_COLOR_UNKNOWN  = 0,                 /**< Color attribute is unused. */
+    NVTX_COLOR_ARGB     = 1                  /**< An ARGB color is provided. */
+} nvtxColorType_t;
+
+/** ---------------------------------------------------------------------------
+ * Message Types
+ * ------------------------------------------------------------------------- */
+typedef enum nvtxMessageType_t
+{
+    NVTX_MESSAGE_UNKNOWN          = 0,    /**< Message attribute is unused. */
+    NVTX_MESSAGE_TYPE_ASCII       = 1,    /**< A character sequence is used as payload. */
+    NVTX_MESSAGE_TYPE_UNICODE     = 2,     /**< A wide character sequence is used as payload. */
+    /* NVTX_VERSION_2 */
+    NVTX_MESSAGE_TYPE_REGISTERED  = 3     /**< A unique string handle that was registered
+                                                with \ref nvtxDomainRegisterStringA() or
+                                                \ref nvtxDomainRegisterStringW(). */
+} nvtxMessageType_t;
+
+typedef union nvtxMessageValue_t
+{
+    const char* ascii;
+    const wchar_t* unicode;
+    /* NVTX_VERSION_2 */
+    nvtxStringHandle_t registered;
+} nvtxMessageValue_t;
+
+
+/* ------------------------------------------------------------------------- */
+/** \brief Force initialization (optional)
+ * \anchor FORCE_INITIALIZATION
+*
+* Force NVTX library to initialize.  The first call to any NVTX API function
+* will automatically initialize the entire API.  This can make the first call
+* much slower than subsequent calls.  In applications where the first call to
+* NVTX may be in a performance-critical section, calling nvtxInitialize before
+* any performance-critical sections will ensure NVTX initialization occurs at
+* an acceptable time.  Since nvtxInitialize takes no parameters and has no
+* expected behavior besides initialization, it is convenient to add a call to
+* nvtxInitialize in NVTX-instrumented applications that need to force earlier
+* initialization without changing any other code.  For example, if an app's
+* first NVTX call is nvtxDomainCreate, and it is difficult to move that call
+* earlier because the domain handle must be stored in an object only created
+* at that point, adding a call to nvtxInitialize at the top of main() will
+* ensure the later call to nvtxDomainCreate is as fast as possible.
+*
+* \version NVTX_VERSION_3
+*
+* \param reserved - must be zero or NULL.
+*
+* @{ */
+NVTX_DECLSPEC void NVTX_API nvtxInitialize(const void* reserved);
+/** @} */
+
+
+/** @} */ /*END defgroup*/
+
+/* ========================================================================= */
+/** \defgroup EVENT_ATTRIBUTES Event Attributes
+* @{
+*/
+
+/** ---------------------------------------------------------------------------
+* Payload Types
+* ------------------------------------------------------------------------- */
+typedef enum nvtxPayloadType_t
+{
+    NVTX_PAYLOAD_UNKNOWN = 0,   /**< Payload attribute is unused. */
+    NVTX_PAYLOAD_TYPE_UNSIGNED_INT64 = 1,   /**< A 64 bit unsigned integer value is used as payload. */
+    NVTX_PAYLOAD_TYPE_INT64 = 2,   /**< A 64 bit signed integer value is used as payload. */
+    NVTX_PAYLOAD_TYPE_DOUBLE = 3,   /**< A 64 bit floating point value is used as payload. */
+    /* NVTX_VERSION_2 */
+    NVTX_PAYLOAD_TYPE_UNSIGNED_INT32 = 4,   /**< A 32 bit floating point value is used as payload. */
+    NVTX_PAYLOAD_TYPE_INT32 = 5,   /**< A 32 bit floating point value is used as payload. */
+    NVTX_PAYLOAD_TYPE_FLOAT = 6    /**< A 32 bit floating point value is used as payload. */
+} nvtxPayloadType_t;
+
+/** \brief Event Attribute Structure.
+ * \anchor EVENT_ATTRIBUTE_STRUCTURE
+ *
+ * This structure is used to describe the attributes of an event. The layout of
+ * the structure is defined by a specific version of the tools extension
+ * library and can change between different versions of the Tools Extension
+ * library.
+ *
+ * \par Guidelines
+ * The caller should always perform the following three tasks when using
+ * attributes:
+ * <ul>
+ *    <li>Zero the structure
+ *    <li>Set the version field
+ *    <li>Set the size field
+ * </ul>
+ *
+ * Zeroing the structure sets all the event attributes types and values
+ * to the default value.
+ *
+ * The version and size field are used by the Tools Extension
+ * implementation to handle multiple versions of the attributes structure.
+ *
+ * It is recommended that the caller use one of the following to methods
+ * to initialize the event attributes structure:
+ *
+ * \par Method 1
+ * Initializing nvtxEventAttributes for future compatibility:
+ * \code
+ * nvtxEventAttributes_t eventAttrib = {0};
+ * eventAttrib.version = NVTX_VERSION;
+ * eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+ * \endcode
+ *
+ * \par Method 2
+ * Initializing nvtxEventAttributes for a specific version:
+ * \code
+ * nvtxEventAttributes_t eventAttrib = {0};
+ * eventAttrib.version = 1;
+ * eventAttrib.size = (uint16_t)(sizeof(nvtxEventAttributes_v1));
+ * \endcode
+ *
+ * If the caller uses Method 1 it is critical that the entire binary
+ * layout of the structure be configured to 0 so that all fields
+ * are initialized to the default value.
+ *
+ * The caller should either use both NVTX_VERSION and
+ * NVTX_EVENT_ATTRIB_STRUCT_SIZE (Method 1) or use explicit values
+ * and a versioned type (Method 2).  Using a mix of the two methods
+ * will likely cause either source level incompatibility or binary
+ * incompatibility in the future.
+ *
+ * \par Example
+ * Populate an attributes structure:
+ * \code
+ * // Initialize
+ * nvtxEventAttributes_t eventAttrib = {0};
+ * eventAttrib.version = NVTX_VERSION;
+ * eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+ *
+ * // Configure the Attributes
+ * eventAttrib.colorType = NVTX_COLOR_ARGB;
+ * eventAttrib.color = 0xFF880000;
+ * eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+ * eventAttrib.message.ascii = "Example";
+ * \endcode
+ *
+ * In the example the caller does not have to set the value of
+ * \ref ::nvtxEventAttributes_v2::category or
+ * \ref ::nvtxEventAttributes_v2::payload as these fields were set to
+ * the default value by {0}.
+ * \sa
+ * ::nvtxDomainMarkEx
+ * ::nvtxDomainRangeStartEx
+ * ::nvtxDomainRangePushEx
+ */
+typedef struct nvtxEventAttributes_v2
+{
+    /**
+    * \brief Version flag of the structure.
+    *
+    * Needs to be set to NVTX_VERSION to indicate the version of NVTX APIs
+    * supported in this header file. This can optionally be overridden to
+    * another version of the tools extension library.
+    */
+    uint16_t version;
+
+    /**
+    * \brief Size of the structure.
+    *
+    * Needs to be set to the size in bytes of the event attribute
+    * structure used to specify the event.
+    */
+    uint16_t size;
+
+    /**
+     * \brief ID of the category the event is assigned to.
+     *
+     * A category is a user-controlled ID that can be used to group
+     * events.  The tool may use category IDs to improve filtering or
+     * enable grouping of events in the same category. The functions
+     * \ref ::nvtxNameCategoryA or \ref ::nvtxNameCategoryW can be used
+     * to name a category.
+     *
+     * Default Value is 0
+     */
+    uint32_t category;
+
+    /** \brief Color type specified in this attribute structure.
+     *
+     * Defines the color format of the attribute structure's \ref COLOR_FIELD
+     * "color" field.
+     *
+     * Default Value is NVTX_COLOR_UNKNOWN
+     */
+    int32_t colorType;              /* nvtxColorType_t */
+
+    /** \brief Color assigned to this event. \anchor COLOR_FIELD
+     *
+     * The color that the tool should use to visualize the event.
+     */
+    uint32_t color;
+
+    /**
+     * \brief Payload type specified in this attribute structure.
+     *
+     * Defines the payload format of the attribute structure's \ref PAYLOAD_FIELD
+     * "payload" field.
+     *
+     * Default Value is NVTX_PAYLOAD_UNKNOWN
+     */
+    int32_t payloadType;            /* nvtxPayloadType_t */
+
+    int32_t reserved0;
+
+    /**
+     * \brief Payload assigned to this event. \anchor PAYLOAD_FIELD
+     *
+     * A numerical value that can be used to annotate an event. The tool could
+     * use the payload data to reconstruct graphs and diagrams.
+     */
+    union payload_t
+    {
+        uint64_t ullValue;
+        int64_t llValue;
+        double dValue;
+        /* NVTX_VERSION_2 */
+        uint32_t uiValue;
+        int32_t iValue;
+        float fValue;
+    } payload;
+
+    /** \brief Message type specified in this attribute structure.
+     *
+     * Defines the message format of the attribute structure's \ref MESSAGE_FIELD
+     * "message" field.
+     *
+     * Default Value is NVTX_MESSAGE_UNKNOWN
+     */
+    int32_t messageType;            /* nvtxMessageType_t */
+
+    /** \brief Message assigned to this attribute structure. \anchor MESSAGE_FIELD
+     *
+     * The text message that is attached to an event.
+     */
+    nvtxMessageValue_t message;
+
+} nvtxEventAttributes_v2;
+
+typedef struct nvtxEventAttributes_v2 nvtxEventAttributes_t;
+
+/** @} */ /*END defgroup*/
+/* ========================================================================= */
+/** \defgroup MARKERS_AND_RANGES Markers and Ranges
+ *
+ * See \ref MARKERS_AND_RANGES for more details
+ *
+ * @{
+ */
+
+/** \name Marker */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Marks an instantaneous event in the application.
+*
+* A marker can contain a text message or specify additional information
+* using the event attributes structure.  These attributes include a text
+* message, color, category, and a payload. Each of the attributes is optional
+* and can only be sent out using the \ref nvtxDomainMarkEx function.
+*
+* nvtxDomainMarkEx(NULL, event) is equivalent to calling
+* nvtxMarkEx(event).
+*
+* \param domain    - The domain of scoping the category.
+* \param eventAttrib - The event attribute structure defining the marker's
+* attribute types and attribute values.
+*
+* \sa
+* ::nvtxMarkEx
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC void NVTX_API nvtxDomainMarkEx(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Marks an instantaneous event in the application.
+ *
+ * A marker can contain a text message or specify additional information
+ * using the event attributes structure.  These attributes include a text
+ * message, color, category, and a payload. Each of the attributes is optional
+ * and can only be sent out using the \ref nvtxMarkEx function.
+ * If \ref nvtxMarkA or \ref nvtxMarkW are used to specify the marker
+ * or if an attribute is unspecified then a default value will be used.
+ *
+ * \param eventAttrib - The event attribute structure defining the marker's
+ * attribute types and attribute values.
+ *
+ * \par Example
+ * Place a mark with attributes:
+ * \code
+ * // zero the structure
+ * nvtxEventAttributes_t eventAttrib = {0};
+ * // set the version and the size information
+ * eventAttrib.version = NVTX_VERSION;
+ * eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+ * // configure the attributes.  0 is the default for all attributes.
+ * eventAttrib.colorType = NVTX_COLOR_ARGB;
+ * eventAttrib.color = 0xFF880000;
+ * eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+ * eventAttrib.message.ascii = "Example nvtxMarkEx";
+ * nvtxMarkEx(&eventAttrib);
+ * \endcode
+ *
+ * \sa
+ * ::nvtxDomainMarkEx
+ *
+ * \version NVTX_VERSION_1
+ * @{ */
+NVTX_DECLSPEC void NVTX_API nvtxMarkEx(const nvtxEventAttributes_t* eventAttrib);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Marks an instantaneous event in the application.
+ *
+ * A marker created using \ref nvtxMarkA or \ref nvtxMarkW contains only a
+ * text message.
+ *
+ * \param message     - The message associated to this marker event.
+ *
+ * \par Example
+ * Place a mark:
+ * \code
+ * nvtxMarkA("Example nvtxMarkA");
+ * nvtxMarkW(L"Example nvtxMarkW");
+ * \endcode
+ *
+ * \sa
+ * ::nvtxDomainMarkEx
+ * ::nvtxMarkEx
+ *
+ * \version NVTX_VERSION_0
+ * @{ */
+NVTX_DECLSPEC void NVTX_API nvtxMarkA(const char* message);
+NVTX_DECLSPEC void NVTX_API nvtxMarkW(const wchar_t* message);
+/** @} */
+
+
+/** \name Process Ranges */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Starts a process range in a domain.
+*
+* \param domain    - The domain of scoping the category.
+* \param eventAttrib - The event attribute structure defining the range's
+* attribute types and attribute values.
+*
+* \return The unique ID used to correlate a pair of Start and End events.
+*
+* \remarks Ranges defined by Start/End can overlap.
+*
+* \par Example
+* Start a range with attributes for a domain:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("my domain");
+* nvtxEventAttributes_t eventAttrib = {0};
+* eventAttrib.version = NVTX_VERSION;
+* eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+* eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+* eventAttrib.message.ascii = "my range";
+* nvtxRangeId_t rangeId = nvtxDomainRangeStartEx(domain, &eventAttrib);
+* // ...
+* nvtxDomainRangeEnd(domain, rangeId);
+* \endcode
+*
+* \sa
+* ::nvtxDomainRangeEnd
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxDomainRangeStartEx(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Starts a process range.
+ *
+ * \param eventAttrib - The event attribute structure defining the range's
+ * attribute types and attribute values.
+ *
+ * \return The unique ID used to correlate a pair of Start and End events.
+ *
+ * \remarks Ranges defined by Start/End can overlap.
+ *
+ * \par Example
+ * Start a range with attributes:
+ * \code
+ * nvtxEventAttributes_t eventAttrib = {0};
+ * eventAttrib.version = NVTX_VERSION;
+ * eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+ * eventAttrib.category = 3;
+ * eventAttrib.colorType = NVTX_COLOR_ARGB;
+ * eventAttrib.color = 0xFF0088FF;
+ * eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+ * eventAttrib.message.ascii = "Example Range";
+ * nvtxRangeId_t rangeId = nvtxRangeStartEx(&eventAttrib);
+ * // ...
+ * nvtxRangeEnd(rangeId);
+ * \endcode
+ *
+ * \sa
+ * ::nvtxRangeEnd
+ * ::nvtxDomainRangeStartEx
+ *
+ * \version NVTX_VERSION_1
+ * @{ */
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxRangeStartEx(const nvtxEventAttributes_t* eventAttrib);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Starts a process range.
+ *
+ * \param message     - The event message associated to this range event.
+ *
+ * \return The unique ID used to correlate a pair of Start and End events.
+ *
+ * \remarks Ranges defined by Start/End can overlap.
+ *
+ * \par Example
+ * Start a range:
+ * \code
+ * nvtxRangeId_t r1 = nvtxRangeStartA("Range 1");
+ * nvtxRangeId_t r2 = nvtxRangeStartW(L"Range 2");
+ * nvtxRangeEnd(r1);
+ * nvtxRangeEnd(r2);
+ * \endcode
+ *
+ * \sa
+ * ::nvtxRangeEnd
+ * ::nvtxRangeStartEx
+ * ::nvtxDomainRangeStartEx
+ *
+ * \version NVTX_VERSION_0
+ * @{ */
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxRangeStartA(const char* message);
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxRangeStartW(const wchar_t* message);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Ends a process range.
+*
+* \param domain - The domain
+* \param id - The correlation ID returned from a nvtxRangeStart call.
+*
+* \remarks This function is offered completeness but is an alias for ::nvtxRangeEnd.
+* It does not need a domain param since that is associated with the range ID at ::nvtxDomainRangeStartEx
+*
+* \par Example
+* End a range for a domain:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("my domain");
+* nvtxEventAttributes_t eventAttrib = {0};
+* eventAttrib.version = NVTX_VERSION;
+* eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+* eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+* eventAttrib.message.ascii = "my range";
+* nvtxRangeId_t rangeId = nvtxDomainRangeStartEx(domain, &eventAttrib);
+* // ...
+* nvtxDomainRangeEnd(domain, rangeId);
+* \endcode
+*
+* \sa
+* ::nvtxDomainRangeStartEx
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC void NVTX_API nvtxDomainRangeEnd(nvtxDomainHandle_t domain, nvtxRangeId_t id);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Ends a process range.
+ *
+ * \param id - The correlation ID returned from an nvtxRangeStart call.
+ *
+ * \sa
+ * ::nvtxDomainRangeStartEx
+ * ::nvtxRangeStartEx
+ * ::nvtxRangeStartA
+ * ::nvtxRangeStartW
+ *
+ * \version NVTX_VERSION_0
+ * @{ */
+NVTX_DECLSPEC void NVTX_API nvtxRangeEnd(nvtxRangeId_t id);
+/** @} */
+
+/** \name Thread Ranges */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Starts a nested thread range.
+*
+* \param domain    - The domain of scoping.
+* \param eventAttrib - The event attribute structure defining the range's
+* attribute types and attribute values.
+*
+* \return The 0 based level of range being started. This value is scoped to the domain.
+* If an error occurs, a negative value is returned.
+*
+* \par Example
+* Push a range with attributes for a domain:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("example domain");
+* nvtxEventAttributes_t eventAttrib = {0};
+* eventAttrib.version = NVTX_VERSION;
+* eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+* eventAttrib.colorType = NVTX_COLOR_ARGB;
+* eventAttrib.color = 0xFFFF0000;
+* eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+* eventAttrib.message.ascii = "Level 0";
+* nvtxDomainRangePushEx(domain, &eventAttrib);
+*
+* // Re-use eventAttrib
+* eventAttrib.messageType = NVTX_MESSAGE_TYPE_UNICODE;
+* eventAttrib.message.unicode = L"Level 1";
+* nvtxDomainRangePushEx(domain, &eventAttrib);
+*
+* nvtxDomainRangePop(domain); // Level 1
+* nvtxDomainRangePop(domain); // Level 0
+* \endcode
+*
+* \sa
+* ::nvtxDomainRangePop
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC int NVTX_API nvtxDomainRangePushEx(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Starts a nested thread range.
+ *
+ * \param eventAttrib - The event attribute structure defining the range's
+ * attribute types and attribute values.
+ *
+ * \return The 0 based level of range being started. This level is per domain.
+ * If an error occurs a negative value is returned.
+ *
+ * \par Example
+ * Push a range with attributes:
+ * \code
+ * nvtxEventAttributes_t eventAttrib = {0};
+ * eventAttrib.version = NVTX_VERSION;
+ * eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+ * eventAttrib.colorType = NVTX_COLOR_ARGB;
+ * eventAttrib.color = 0xFFFF0000;
+ * eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+ * eventAttrib.message.ascii = "Level 0";
+ * nvtxRangePushEx(&eventAttrib);
+ *
+ * // Re-use eventAttrib
+ * eventAttrib.messageType = NVTX_MESSAGE_TYPE_UNICODE;
+ * eventAttrib.message.unicode = L"Level 1";
+ * nvtxRangePushEx(&eventAttrib);
+ *
+ * nvtxRangePop(); // Level 1
+ * nvtxRangePop(); // Level 0
+ * \endcode
+ *
+ * \sa
+ * ::nvtxDomainRangePushEx
+ * ::nvtxRangePop
+ *
+ * \version NVTX_VERSION_1
+ * @{ */
+NVTX_DECLSPEC int NVTX_API nvtxRangePushEx(const nvtxEventAttributes_t* eventAttrib);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Starts a nested thread range.
+ *
+ * \param message     - The event message associated to this range event.
+ *
+ * \return The 0 based level of range being started.  If an error occurs a
+ * negative value is returned.
+ *
+ * \par Example
+ * Push a range:
+ * \code
+ * nvtxRangePushA("Level 0");
+ * nvtxRangePushW(L"Level 1");
+ * nvtxRangePop(); // Level 1
+ * nvtxRangePop(); // Level 0
+ * \endcode
+ *
+ * \sa
+ * ::nvtxDomainRangePushEx
+ * ::nvtxRangePop
+ *
+ * \version NVTX_VERSION_0
+ * @{ */
+NVTX_DECLSPEC int NVTX_API nvtxRangePushA(const char* message);
+NVTX_DECLSPEC int NVTX_API nvtxRangePushW(const wchar_t* message);
+/** @} */
+
+
+/* ------------------------------------------------------------------------- */
+/** \brief Ends a nested thread range.
+*
+* \return The level of the range being ended. If an error occurs a negative
+* value is returned on the current thread.
+*
+* \par Example
+* Pop a range for a domain:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("example domain");
+* nvtxEventAttributes_t eventAttrib = {0};
+* eventAttrib.version = NVTX_VERSION;
+* eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+* eventAttrib.colorType = NVTX_COLOR_ARGB;
+* eventAttrib.color = 0xFFFF0000;
+* eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+* eventAttrib.message.ascii = "Level 0";
+* nvtxDomainRangePushEx(domain, &eventAttrib);
+*
+* // Re-use eventAttrib
+* eventAttrib.messageType = NVTX_MESSAGE_TYPE_UNICODE;
+* eventAttrib.message.unicode = L"Level 1";
+* nvtxDomainRangePushEx(domain, &eventAttrib);
+*
+* nvtxDomainRangePop(domain); // Level 1
+* nvtxDomainRangePop(domain); // Level 0
+* \endcode
+*
+* \sa
+* ::nvtxRangePushEx
+* ::nvtxRangePushA
+* ::nvtxRangePushW
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC int NVTX_API nvtxDomainRangePop(nvtxDomainHandle_t domain);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Ends a nested thread range.
+ *
+ * \return The level of the range being ended. If an error occurs a negative
+ * value is returned on the current thread.
+ *
+ * \par Example
+ * Pop a range:
+ * \code
+ * nvtxRangePushA("Level 0");
+ * nvtxRangePushW(L"Level 1");
+ * nvtxRangePop(); // Level 1
+ * nvtxRangePop(); // Level 0
+ * \endcode
+ *
+ * \sa
+ * ::nvtxRangePushEx
+ * ::nvtxRangePushA
+ * ::nvtxRangePushW
+ *
+ * \version NVTX_VERSION_0
+ * @{ */
+NVTX_DECLSPEC int NVTX_API nvtxRangePop(void);
+/** @} */
+
+
+/** @} */ /*END defgroup*/
+/* ========================================================================= */
+/** \defgroup RESOURCE_NAMING Resource Naming
+ *
+ * See \ref RESOURCE_NAMING for more details
+ *
+ * @{
+ */
+
+
+/*  ------------------------------------------------------------------------- */
+/** \name Functions for Generic Resource Naming*/
+/*  ------------------------------------------------------------------------- */
+
+/*  ------------------------------------------------------------------------- */
+/** \cond SHOW_HIDDEN
+* \brief Resource typing helpers.
+*
+* Classes are used to make it easy to create a series of resource types
+* per API without collisions
+*/
+#define NVTX_RESOURCE_MAKE_TYPE(CLASS, INDEX) (((NVTX_STATIC_CAST(uint32_t, NVTX_RESOURCE_CLASS_ ## CLASS))<<16)|(NVTX_STATIC_CAST(uint32_t, INDEX)))
+#define NVTX_RESOURCE_CLASS_GENERIC 1
+/** \endcond */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Generic resource type for when a resource class is not available.
+*
+* \sa
+* ::nvtxDomainResourceCreate
+*
+* \version NVTX_VERSION_2
+*/
+typedef enum nvtxResourceGenericType_t
+{
+    NVTX_RESOURCE_TYPE_UNKNOWN = 0,
+    NVTX_RESOURCE_TYPE_GENERIC_POINTER = NVTX_RESOURCE_MAKE_TYPE(GENERIC, 1), /*!< Generic pointer assumed to have no collisions with other pointers. */
+    NVTX_RESOURCE_TYPE_GENERIC_HANDLE = NVTX_RESOURCE_MAKE_TYPE(GENERIC, 2), /**< Generic handle assumed to have no collisions with other handles. */
+    NVTX_RESOURCE_TYPE_GENERIC_THREAD_NATIVE = NVTX_RESOURCE_MAKE_TYPE(GENERIC, 3), /**< OS native thread identifier. */
+    NVTX_RESOURCE_TYPE_GENERIC_THREAD_POSIX = NVTX_RESOURCE_MAKE_TYPE(GENERIC, 4) /**< POSIX pthread identifier. */
+} nvtxResourceGenericType_t;
+
+
+
+/** \brief Resource Attribute Structure.
+* \anchor RESOURCE_ATTRIBUTE_STRUCTURE
+*
+* This structure is used to describe the attributes of a resource. The layout of
+* the structure is defined by a specific version of the tools extension
+* library and can change between different versions of the Tools Extension
+* library.
+*
+* \par Guidelines
+* The caller should always perform the following three tasks when using
+* attributes:
+* <ul>
+*    <li>Zero the structure
+*    <li>Set the version field
+*    <li>Set the size field
+* </ul>
+*
+* Zeroing the structure sets all the resource attributes types and values
+* to the default value.
+*
+* The version and size field are used by the Tools Extension
+* implementation to handle multiple versions of the attributes structure.
+*
+* It is recommended that the caller use one of the following to methods
+* to initialize the event attributes structure:
+*
+* \par Method 1
+* Initializing nvtxEventAttributes for future compatibility:
+* \code
+* nvtxResourceAttributes_t attribs = {0};
+* attribs.version = NVTX_VERSION;
+* attribs.size = NVTX_RESOURCE_ATTRIB_STRUCT_SIZE;
+* \endcode
+*
+* \par Method 2
+* Initializing nvtxEventAttributes for a specific version:
+* \code
+* nvtxResourceAttributes_v0 attribs = {0};
+* attribs.version = 2;
+* attribs.size = (uint16_t)(sizeof(nvtxResourceAttributes_v0));
+* \endcode
+*
+* If the caller uses Method 1 it is critical that the entire binary
+* layout of the structure be configured to 0 so that all fields
+* are initialized to the default value.
+*
+* The caller should either use both NVTX_VERSION and
+* NVTX_RESOURCE_ATTRIB_STRUCT_SIZE (Method 1) or use explicit values
+* and a versioned type (Method 2).  Using a mix of the two methods
+* will likely cause either source level incompatibility or binary
+* incompatibility in the future.
+*
+* \par Example
+* Register a resource and populate its attributes:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("example domain");
+*
+* // Initialize
+* nvtxResourceAttributes_t attribs = {0};
+* attribs.version = NVTX_VERSION;
+* attribs.size = NVTX_RESOURCE_ATTRIB_STRUCT_SIZE;
+*
+* // Configure the Attributes
+* attribs.identifierType = NVTX_RESOURCE_TYPE_GENERIC_POINTER;
+* attribs.identifier.pValue = (const void*)pMutex;
+* attribs.messageType = NVTX_MESSAGE_TYPE_ASCII;
+* attribs.message.ascii = "Single thread access to database.";
+*
+* nvtxResourceHandle_t handle = nvtxDomainResourceCreate(domain, &attribs);
+* \endcode
+*
+* \sa
+* ::nvtxDomainResourceCreate
+*/
+typedef struct nvtxResourceAttributes_v0
+{
+    /**
+    * \brief Version flag of the structure.
+    *
+    * Needs to be set to NVTX_VERSION to indicate the version of NVTX APIs
+    * supported in this header file. This can optionally be overridden to
+    * another version of the tools extension library.
+    */
+    uint16_t version;
+
+    /**
+    * \brief Size of the structure.
+    *
+    * Needs to be set to the size in bytes of this attribute
+    * structure.
+    */
+    uint16_t size;
+
+    /**
+    * \brief Identifier type specifies how to interpret the identifier field
+    *
+    * Defines the identifier format of the attribute structure's \ref RESOURCE_IDENTIFIER_FIELD
+    * "identifier" field.
+    *
+    * Default Value is NVTX_RESOURCE_TYPE_UNKNOWN
+    */
+    int32_t identifierType;            /* values from enums following the pattern nvtxResource[name]Type_t */
+
+    /**
+    * \brief Identifier for the resource.
+    * \anchor RESOURCE_IDENTIFIER_FIELD
+    *
+    * An identifier may be a pointer or a handle to an OS or middleware API object.
+    * The resource type will assist in avoiding collisions where handles values may collide.
+    */
+    union identifier_t
+    {
+        const void* pValue;
+        uint64_t ullValue;
+    } identifier;
+
+    /** \brief Message type specified in this attribute structure.
+    *
+    * Defines the message format of the attribute structure's \ref RESOURCE_MESSAGE_FIELD
+    * "message" field.
+    *
+    * Default Value is NVTX_MESSAGE_UNKNOWN
+    */
+    int32_t messageType;            /* nvtxMessageType_t */
+
+    /** \brief Message assigned to this attribute structure. \anchor RESOURCE_MESSAGE_FIELD
+    *
+    * The text message that is attached to a resource.
+    */
+    nvtxMessageValue_t message;
+
+} nvtxResourceAttributes_v0;
+
+typedef struct nvtxResourceAttributes_v0 nvtxResourceAttributes_t;
+
+/* \cond SHOW_HIDDEN
+* \version NVTX_VERSION_2
+*/
+#define NVTX_RESOURCE_ATTRIB_STRUCT_SIZE (NVTX_STATIC_CAST(uint16_t, sizeof(nvtxResourceAttributes_v0)))
+typedef struct nvtxResourceHandle* nvtxResourceHandle_t;
+/** \endcond */
+
+
+
+/* ------------------------------------------------------------------------- */
+/** \brief Create a resource object to track and associate data with OS and middleware objects
+*
+* Allows users to associate an API handle or pointer with a user-provided name.
+*
+*
+* \param domain - Domain to own the resource object
+* \param attribs - Attributes to be associated with the resource
+*
+* \return A handle that represents the newly created resource object.
+*
+* \par Example
+* Register a resource:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("example domain");
+* nvtxResourceAttributes_t attribs = {0};
+* attribs.version = NVTX_VERSION;
+* attribs.size = NVTX_RESOURCE_ATTRIB_STRUCT_SIZE;
+* attribs.identifierType = NVTX_RESOURCE_TYPE_GENERIC_POINTER;
+* attribs.identifier.pValue = (const void*)pMutex;
+* attribs.messageType = NVTX_MESSAGE_TYPE_ASCII;
+* attribs.message.ascii = "Single thread access to database.";
+* nvtxResourceHandle_t handle = nvtxDomainResourceCreate(domain, &attribs);
+* \endcode
+*
+* \sa
+* ::nvtxResourceAttributes_t
+* ::nvtxDomainResourceDestroy
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC nvtxResourceHandle_t NVTX_API nvtxDomainResourceCreate(nvtxDomainHandle_t domain, nvtxResourceAttributes_t* attribs);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Destroy a resource object to track and associate data with OS and middleware objects
+*
+* Allows users to associate an API handle or pointer with a user-provided name.
+*
+* \param resource - Handle to the resource in which to operate.
+*
+* \par Example
+* Unregister a resource:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("example domain");
+* nvtxResourceAttributes_t attribs = {0};
+* attribs.version = NVTX_VERSION;
+* attribs.size = NVTX_RESOURCE_ATTRIB_STRUCT_SIZE;
+* attribs.identifierType = NVTX_RESOURCE_TYPE_GENERIC_POINTER;
+* attribs.identifier.pValue = (const void*)pMutex;
+* attribs.messageType = NVTX_MESSAGE_TYPE_ASCII;
+* attribs.message.ascii = "Single thread access to database.";
+* nvtxResourceHandle_t handle = nvtxDomainResourceCreate(domain, &attribs);
+* // ...
+* nvtxDomainResourceDestroy(handle);
+* \endcode
+*
+* \sa
+* ::nvtxDomainResourceCreate
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC void NVTX_API nvtxDomainResourceDestroy(nvtxResourceHandle_t resource);
+/** @} */
+
+
+/** \name Functions for NVTX Category Naming*/
+
+/* ------------------------------------------------------------------------- */
+/**
+* \brief Annotate an NVTX category used within a domain.
+*
+* Categories are used to group sets of events. Each category is identified
+* through a unique ID and that ID is passed into any of the marker/range
+* events to assign that event to a specific category. The nvtxDomainNameCategory
+* function calls allow the user to assign a name to a category ID that is
+* specific to the domain.
+*
+* nvtxDomainNameCategory(NULL, category, name) is equivalent to calling
+* nvtxNameCategory(category, name).
+*
+* \param domain    - The domain of scoping the category.
+* \param category  - The category ID to name.
+* \param name      - The name of the category.
+*
+* \remarks The category names are tracked per domain.
+*
+* \par Example
+* Assign names to categories in a domain:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("example");
+* nvtxDomainNameCategoryA(domain, 1, "Memory Allocation");
+* nvtxDomainNameCategoryW(domain, 2, L"Memory Transfer");
+* \endcode
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC void NVTX_API nvtxDomainNameCategoryA(nvtxDomainHandle_t domain, uint32_t category, const char* name);
+NVTX_DECLSPEC void NVTX_API nvtxDomainNameCategoryW(nvtxDomainHandle_t domain, uint32_t category, const wchar_t* name);
+/** @} */
+
+/** \brief Annotate an NVTX category.
+ *
+ * Categories are used to group sets of events. Each category is identified
+ * through a unique ID and that ID is passed into any of the marker/range
+ * events to assign that event to a specific category. The nvtxNameCategory
+ * function calls allow the user to assign a name to a category ID.
+ *
+ * \param category - The category ID to name.
+ * \param name     - The name of the category.
+ *
+ * \remarks The category names are tracked per process.
+ *
+ * \par Example
+ * Assign names to categories:
+ * \code
+ * nvtxNameCategory(1, "Memory Allocation");
+ * nvtxNameCategory(2, "Memory Transfer");
+ * nvtxNameCategory(3, "Memory Object Lifetime");
+ * \endcode
+ *
+ * \version NVTX_VERSION_1
+ * @{ */
+NVTX_DECLSPEC void NVTX_API nvtxNameCategoryA(uint32_t category, const char* name);
+NVTX_DECLSPEC void NVTX_API nvtxNameCategoryW(uint32_t category, const wchar_t* name);
+/** @} */
+
+/** \name Functions for OS Threads Naming*/
+
+/* ------------------------------------------------------------------------- */
+/** \brief Annotate an OS thread.
+ *
+ * Allows the user to name an active thread of the current process. If an
+ * invalid thread ID is provided or a thread ID from a different process is
+ * used the behavior of the tool is implementation dependent.
+ *
+ * Tools expect thread ID to be a number that uniquely identifies the thread
+ * at the time of the call. Note that a thread's ID can be reused after
+ * it is destroyed. Tools may choose how to handle aliasing of thread IDs.
+ *
+ * POSIX pthread_t type returned by pthread_self() may not comply with these
+ * expectations. Please use OS-specific thread ID instead of pthread_t.
+ *
+ * The thread name is associated to the default domain.  To support domains
+ * use resource objects via ::nvtxDomainResourceCreate.
+ *
+ * \param threadId - The ID of the thread to name.
+ * \param name     - The name of the thread.
+ *
+ * \par Examples
+ * Name a thread based on the given operating system:
+ *
+ * Windows:
+ * \code
+ * #include <windows.h>
+ * nvtxNameOsThread(GetCurrentThreadId(), "Current thread");
+ * nvtxNameOsThread(GetThreadId(SomeThreadHandle), "Other thread");
+ * \endcode
+ *
+ * Android:
+ * \code
+ * #include <unistd.h>
+ * nvtxNameOsThreadA(gettid(), "Current thread");
+ * nvtxNameOsThreadA(getpid(), "Main thread");
+ * \endcode
+ *
+ * Linux:
+ * \code
+ * #include <sys/syscall.h>
+ * nvtxNameOsThreadA(syscall(SYS_gettid), "Current thread");
+ * \endcode
+ * \code
+ * #include <unistd.h>
+ * nvtxNameOsThreadA(getpid(), "Main thread");
+ * \endcode
+ *
+ * macOS:
+ * \code
+ * #include <sys/syscall.h>
+ * nvtxNameOsThreadA(syscall(SYS_thread_selfid), "Current thread");
+ * \endcode
+ * \code
+ * #include <pthread.h>
+ * __uint64_t id;
+ * pthread_threadid_np(pthread_self(), &id);
+ * nvtxNameOsThreadA(id, "Current thread");
+ * pthread_threadid_np(somePThreadId, &id);
+ * nvtxNameOsThreadA(id, "Other thread");
+ * \endcode
+ *
+ * \version NVTX_VERSION_1
+ * @{ */
+NVTX_DECLSPEC void NVTX_API nvtxNameOsThreadA(uint32_t threadId, const char* name);
+NVTX_DECLSPEC void NVTX_API nvtxNameOsThreadW(uint32_t threadId, const wchar_t* name);
+/** @} */
+
+
+/** @} */ /*END defgroup*/
+/* ========================================================================= */
+/** \defgroup STRING_REGISTRATION String Registration
+*
+* Registered strings are intended to increase performance by lowering instrumentation
+* overhead.  String may be registered once and the handle may be passed in place of
+* a string where an the APIs may allow.
+*
+* See \ref STRING_REGISTRATION for more details
+*
+* @{
+*/
+
+/* ------------------------------------------------------------------------- */
+/** \brief Register a string.
+
+* Registers an immutable string with NVTX. Once registered the pointer used
+* to register the domain name can be used in nvtxEventAttributes_t
+* \ref MESSAGE_FIELD. This allows NVTX implementation to skip copying the
+* contents of the message on each event invocation.
+*
+* String registration is an optimization. It is recommended to use string
+* registration if the string will be passed to an event many times.
+*
+* String are not unregistered, except that by unregistering the entire domain
+*
+* \param domain  - Domain handle. If NULL then the global domain is used.
+* \param string    - A unique pointer to a sequence of characters.
+*
+* \return A handle representing the registered string.
+*
+* \par Example
+* Register a string:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("com.nvidia.nvtx.example");
+* nvtxStringHandle_t message = nvtxDomainRegisterStringA(domain, "registered string");
+* nvtxEventAttributes_t eventAttrib = {0};
+* eventAttrib.version = NVTX_VERSION;
+* eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+* eventAttrib.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
+* eventAttrib.message.registered = message;
+* \endcode
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC nvtxStringHandle_t NVTX_API nvtxDomainRegisterStringA(nvtxDomainHandle_t domain, const char* string);
+NVTX_DECLSPEC nvtxStringHandle_t NVTX_API nvtxDomainRegisterStringW(nvtxDomainHandle_t domain, const wchar_t* string);
+/** @} */
+
+/** @} */ /*END defgroup*/
+/* ========================================================================= */
+/** \defgroup DOMAINS Domains
+*
+* Domains are used to group events to a developer defined scope. Middleware
+* vendors may also scope their own events to avoid collisions with the
+* the application developer's events, so that the application developer may
+* inspect both parts and easily differentiate or filter them.  By default
+* all events are scoped to a global domain where NULL is provided or when
+* using APIs provided b versions of NVTX below v2
+*
+* Domains are intended to be typically long lived objects with the intention
+* of logically separating events of large modules from each other such as
+* middleware libraries from each other and the main application.
+*
+* See \ref DOMAINS for more details
+*
+* @{
+*/
+
+/* ------------------------------------------------------------------------- */
+/** \brief Register a NVTX domain.
+*
+* Domains are used to scope annotations. All NVTX_VERSION_0 and NVTX_VERSION_1
+* annotations are scoped to the global domain. The function nvtxDomainCreate
+* creates a new named domain.
+*
+* Each domain maintains its own nvtxRangePush and nvtxRangePop stack.
+*
+* \param name - A unique string representing the domain.
+*
+* \return A handle representing the domain.
+*
+* \par Example
+* Create a domain:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("com.nvidia.nvtx.example");
+*
+* nvtxMarkA("nvtxMarkA to global domain");
+*
+* nvtxEventAttributes_t eventAttrib1 = {0};
+* eventAttrib1.version = NVTX_VERSION;
+* eventAttrib1.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+* eventAttrib1.message.ascii = "nvtxDomainMarkEx to global domain";
+* nvtxDomainMarkEx(NULL, &eventAttrib1);
+*
+* nvtxEventAttributes_t eventAttrib2 = {0};
+* eventAttrib2.version = NVTX_VERSION;
+* eventAttrib2.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+* eventAttrib2.message.ascii = "nvtxDomainMarkEx to com.nvidia.nvtx.example";
+* nvtxDomainMarkEx(domain, &eventAttrib2);
+*
+* nvtxDomainDestroy(domain);
+* \endcode
+*
+* \sa
+* ::nvtxDomainDestroy
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC nvtxDomainHandle_t NVTX_API nvtxDomainCreateA(const char* name);
+NVTX_DECLSPEC nvtxDomainHandle_t NVTX_API nvtxDomainCreateW(const wchar_t* name);
+/** @} */
+
+/* ------------------------------------------------------------------------- */
+/** \brief Unregister a NVTX domain.
+*
+* Unregisters the domain handle and frees all domain specific resources.
+*
+* \param domain    - the domain handle
+*
+* \par Example
+* Destroy a domain:
+* \code
+* nvtxDomainHandle_t domain = nvtxDomainCreateA("com.nvidia.nvtx.example");
+* // ...
+* nvtxDomainDestroy(domain);
+* \endcode
+*
+* \sa
+* ::nvtxDomainCreateA
+* ::nvtxDomainCreateW
+*
+* \version NVTX_VERSION_2
+* @{ */
+NVTX_DECLSPEC void NVTX_API nvtxDomainDestroy(nvtxDomainHandle_t domain);
+/** @} */
+
+
+/** @} */ /*END defgroup*/
+/* ========================================================================= */
+/** \cond SHOW_HIDDEN */
+
+#ifdef UNICODE
+    #define nvtxMark            nvtxMarkW
+    #define nvtxRangeStart      nvtxRangeStartW
+    #define nvtxRangePush       nvtxRangePushW
+    #define nvtxNameCategory    nvtxNameCategoryW
+    #define nvtxNameOsThread    nvtxNameOsThreadW
+    /* NVTX_VERSION_2 */
+    #define nvtxDomainCreate         nvtxDomainCreateW
+    #define nvtxDomainRegisterString nvtxDomainRegisterStringW
+    #define nvtxDomainNameCategory   nvtxDomainNameCategoryW
+#else
+    #define nvtxMark            nvtxMarkA
+    #define nvtxRangeStart      nvtxRangeStartA
+    #define nvtxRangePush       nvtxRangePushA
+    #define nvtxNameCategory    nvtxNameCategoryA
+    #define nvtxNameOsThread    nvtxNameOsThreadA
+    /* NVTX_VERSION_2 */
+    #define nvtxDomainCreate         nvtxDomainCreateA
+    #define nvtxDomainRegisterString nvtxDomainRegisterStringA
+    #define nvtxDomainNameCategory   nvtxDomainNameCategoryA
+#endif
+
+/** \endcond */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#define NVTX_IMPL_GUARD /* Ensure other headers cannot be included directly */
+
+#include "nvtxDetail/nvtxTypes.h"
+
+#ifndef NVTX_NO_IMPL
+#include "nvtxDetail/nvtxImpl.h"
+#endif /*NVTX_NO_IMPL*/
+
+#undef NVTX_IMPL_GUARD
+
+#endif /* !defined(NVTX_VERSION) */

--- a/third_party/nvtx/include/nvtx3/nvToolsExtPayload.h
+++ b/third_party/nvtx/include/nvtx3/nvToolsExtPayload.h
@@ -1,0 +1,1478 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+#include "nvToolsExt.h"
+
+/* Optionally include helper macros. */
+/* #include "nvToolsExtPayloadHelper.h" */
+
+/**
+ * If needed, semantic extension headers can be included after this header.
+ */
+
+/**
+ * \brief The compatibility ID is used for versioning of this extension.
+ */
+#ifndef NVTX_EXT_PAYLOAD_COMPATID
+#define NVTX_EXT_PAYLOAD_COMPATID 0x0104
+#endif
+
+/**
+ * \brief The module ID identifies the payload extension. It has to be unique
+ * among the extension modules.
+ */
+#ifndef NVTX_EXT_PAYLOAD_MODULEID
+#define NVTX_EXT_PAYLOAD_MODULEID 2
+#endif
+
+/**
+ * \brief Additional value for the enum @ref nvtxPayloadType_t
+ */
+#ifndef NVTX_PAYLOAD_TYPE_EXT
+#define NVTX_PAYLOAD_TYPE_EXT (NVTX_STATIC_CAST(int32_t, 0xDFBD0009))
+#endif
+
+/** ---------------------------------------------------------------------------
+ * Payload schema entry flags. Used for @ref nvtxPayloadSchemaEntry_t::flags.
+ * ------------------------------------------------------------------------- */
+#ifndef NVTX_PAYLOAD_ENTRY_FLAGS_V1
+#define NVTX_PAYLOAD_ENTRY_FLAGS_V1
+
+#define NVTX_PAYLOAD_ENTRY_FLAG_UNUSED 0
+
+/**
+ * Absolute pointer into a payload (entry) of the same event.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_POINTER          (1 << 1)
+
+/**
+ * Offset from base address of the payload.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_OFFSET_FROM_BASE (1 << 2)
+
+/**
+ * Offset from the end of this payload entry.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_OFFSET_FROM_HERE (1 << 3)
+
+/**
+ * The value is an array with fixed length, set with the field `arrayLength`.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_FIXED_SIZE           (1 << 4)
+
+/**
+ * The value is a zero-/null-terminated array.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_ZERO_TERMINATED      (2 << 4)
+
+/**
+ * \brief A single or multi-dimensional array of variable length.
+ *
+ * The field `arrayOrUnionDetail` contains the index of the schema entry that
+ * holds the length(s). If the length entry is a scalar, then this entry is a 1D
+ * array. If the length entry is a fixed-size array, then the number of
+ * dimensions is defined with the registration of the schema. If the length
+ * entry is a zero-terminated array, then the array of the dimensions can be
+ * determined at runtime.
+ * For multidimensional arrays, values are stored in row-major order, with rows
+ * being stored consecutively in contiguous memory. The size of the entry (in
+ * bytes) is the product of the dimensions multiplied with size of the array
+ * element.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_LENGTH_INDEX         (3 << 4)
+
+/**
+ * \brief A single or multi-dimensional array of variable length, where the
+ * dimensions are stored in a different payload (index) of the same event.
+ *
+ * This enables an existing address to an array to be directly passed, while the
+ * dimensions are defined in a separate payload (with only one payload entry).
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_LENGTH_PAYLOAD_INDEX (4 << 4)
+
+/**
+ * \brief The value or data that is pointed to by this payload entry value shall
+ * be copied by the NVTX handler.
+ *
+ * A tool may not support deep copy and just ignore this flag.
+ * See @ref NVTX_PAYLOAD_SCHEMA_FLAG_DEEP_COPY for more details.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_DEEP_COPY          (1 << 8)
+
+/**
+ * Notifies the NVTX handler to hide this entry in case of visualization.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_HIDE               (1 << 9)
+
+/**
+ * The entry specifies the event message. Any string type can be used.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE      (1 << 10)
+
+/**
+ * \brief The entry contains a timestamp.
+ *
+ * The time source might be provided via the entry semantics field. In most
+ * cases, the timestamp (entry) type is @ref NVTX_PAYLOAD_ENTRY_TYPE_INT64.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_TIMESTAMP          (2 << 10)
+
+/**
+ * These flags specify the NVTX event type to which an entry refers.
+ */
+#define NVTX_PAYLOAD_ENTRY_FLAG_RANGE_BEGIN        (1 << 12)
+#define NVTX_PAYLOAD_ENTRY_FLAG_RANGE_END          (2 << 12)
+#define NVTX_PAYLOAD_ENTRY_FLAG_MARK               (3 << 12)
+#define NVTX_PAYLOAD_ENTRY_FLAG_COUNTER            (4 << 12)
+
+#endif /* NVTX_PAYLOAD_ENTRY_FLAGS_V1 */
+/** ---------------------------------------------------------------------------
+ * END: Payload schema entry flags.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * @note The 'array' flags assume that the array is embedded. Otherwise,
+ * @ref NVTX_PAYLOAD_ENTRY_FLAG_POINTER has to be additionally specified. Some
+ * combinations may be invalid based on the `NVTX_PAYLOAD_SCHEMA_TYPE_*` this
+ * entry is enclosed. For instance, variable length embedded arrays are valid
+ * within @ref NVTX_PAYLOAD_SCHEMA_TYPE_DYNAMIC but invalid with
+ * @ref NVTX_PAYLOAD_SCHEMA_TYPE_STATIC. See `NVTX_PAYLOAD_SCHEMA_TYPE_*` for
+ * additional details.
+ */
+
+/* Helper macro to check if an entry represents an array. */
+#define NVTX_PAYLOAD_ENTRY_FLAG_IS_ARRAY (\
+    NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_FIXED_SIZE | \
+    NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_ZERO_TERMINATED | \
+    NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_LENGTH_INDEX)
+
+#define NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_TYPE(F) \
+    ((F) & NVTX_PAYLOAD_ENTRY_FLAG_IS_ARRAY)
+
+
+/** ---------------------------------------------------------------------------
+ * Types of entries in a payload schema.
+ *
+ * @note Several of the predefined types contain the size (in bits) in their
+ * names. For some data types the size (in bytes) is not fixed and may differ
+ * for different platforms/operating systems/compilers. To provide portability,
+ * an array of sizes (in bytes) for type 1 to 28 ( @ref
+ * NVTX_PAYLOAD_ENTRY_TYPE_CHAR to @ref NVTX_PAYLOAD_ENTRY_TYPE_INFO_ARRAY_SIZE)
+ * is passed to the NVTX extension initialization function
+ * @ref InitializeInjectionNvtxExtension via the `extInfo` field of
+ * @ref nvtxExtModuleInfo_t.
+ * ------------------------------------------------------------------------- */
+#ifndef NVTX_PAYLOAD_ENTRY_TYPES_V1
+#define NVTX_PAYLOAD_ENTRY_TYPES_V1
+
+#define NVTX_PAYLOAD_ENTRY_TYPE_INVALID     0
+
+/**
+ * Basic integer types.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_CHAR        1
+#define NVTX_PAYLOAD_ENTRY_TYPE_UCHAR       2
+#define NVTX_PAYLOAD_ENTRY_TYPE_SHORT       3
+#define NVTX_PAYLOAD_ENTRY_TYPE_USHORT      4
+#define NVTX_PAYLOAD_ENTRY_TYPE_INT         5
+#define NVTX_PAYLOAD_ENTRY_TYPE_UINT        6
+#define NVTX_PAYLOAD_ENTRY_TYPE_LONG        7
+#define NVTX_PAYLOAD_ENTRY_TYPE_ULONG       8
+#define NVTX_PAYLOAD_ENTRY_TYPE_LONGLONG    9
+#define NVTX_PAYLOAD_ENTRY_TYPE_ULONGLONG  10
+
+/**
+ * Integer types with explicit size.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_INT8       11
+#define NVTX_PAYLOAD_ENTRY_TYPE_UINT8      12
+#define NVTX_PAYLOAD_ENTRY_TYPE_INT16      13
+#define NVTX_PAYLOAD_ENTRY_TYPE_UINT16     14
+#define NVTX_PAYLOAD_ENTRY_TYPE_INT32      15
+#define NVTX_PAYLOAD_ENTRY_TYPE_UINT32     16
+#define NVTX_PAYLOAD_ENTRY_TYPE_INT64      17
+#define NVTX_PAYLOAD_ENTRY_TYPE_UINT64     18
+
+/**
+ * Floating point types
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_FLOAT      19
+#define NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE     20
+#define NVTX_PAYLOAD_ENTRY_TYPE_LONGDOUBLE 21
+
+/**
+ * Size type (`size_t` in C).
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_SIZE       22
+
+/**
+ * Any address, e.g. `void*`. If the pointer type matters, use the flag @ref
+ * NVTX_PAYLOAD_ENTRY_FLAG_POINTER and the respective type instead.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_ADDRESS    23
+
+/**
+ * Special character types.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_WCHAR      24 /* wide character (since C90) */
+#define NVTX_PAYLOAD_ENTRY_TYPE_CHAR8      25 /* since C2x and C++20 */
+#define NVTX_PAYLOAD_ENTRY_TYPE_CHAR16     26
+#define NVTX_PAYLOAD_ENTRY_TYPE_CHAR32     27
+
+/**
+ * There is type size and alignment information for all previous types.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_INFO_ARRAY_SIZE (NVTX_PAYLOAD_ENTRY_TYPE_CHAR32 + 1)
+
+/**
+ * Store raw 8-bit binary data. As with `char`, 1-byte alignment is assumed.
+ * Typically, a tool will display this as hex or binary.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_BYTE       32
+
+/**
+ * These types do not have standardized equivalents. It is assumed that the
+ * number at the end corresponds to the bits used to store the value and that
+ * the alignment corresponds to standardized types of the same size.
+ * A tool may not support these types.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_INT128     33
+#define NVTX_PAYLOAD_ENTRY_TYPE_UINT128    34
+
+#define NVTX_PAYLOAD_ENTRY_TYPE_FLOAT16    42
+#define NVTX_PAYLOAD_ENTRY_TYPE_FLOAT32    43
+#define NVTX_PAYLOAD_ENTRY_TYPE_FLOAT64    44
+#define NVTX_PAYLOAD_ENTRY_TYPE_FLOAT128   45
+
+#define NVTX_PAYLOAD_ENTRY_TYPE_BF16       50
+#define NVTX_PAYLOAD_ENTRY_TYPE_TF32       52
+
+/**
+ * Data types are as defined by NVTXv3 core.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_CATEGORY   68 /* uint32_t */
+#define NVTX_PAYLOAD_ENTRY_TYPE_COLOR_ARGB 69 /* uint32_t */
+
+/**
+ * The scope of events or counters (see `nvtxScopeRegister`).
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_SCOPE_ID   70 /* uint64_t */
+
+/**
+ * Process ID as scope.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_PID_UINT32 71
+#define NVTX_PAYLOAD_ENTRY_TYPE_PID_UINT64 72
+
+/**
+ * Thread ID as scope.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_TID_UINT32 73
+#define NVTX_PAYLOAD_ENTRY_TYPE_TID_UINT64 74
+
+/**
+ * \brief String types.
+ *
+ * If no flags are set for the entry and `arrayOrUnionDetail > 0`, the entry is
+ * assumed to be a fixed-size string with the given length, embedded in the payload.
+ * `NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_FIXED_SIZE` is redundant for fixed-size strings.
+ *
+ * Setting the flag `NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_ZERO_TERMINATED` specifies a
+ * zero-terminated string. If `arrayOrUnionDetail > 0`, the entry is handled as
+ * a zero-terminated array of fixed-size strings.
+ *
+ * Setting the flag `NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_LENGTH_INDEX` specifies a
+ * variable-length string with the length given in the entry specified by the
+ * field `arrayOrUnionDetail`.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_CSTRING       75 /* `char*`, system LOCALE */
+#define NVTX_PAYLOAD_ENTRY_TYPE_CSTRING_UTF8  76
+#define NVTX_PAYLOAD_ENTRY_TYPE_CSTRING_UTF16 77
+#define NVTX_PAYLOAD_ENTRY_TYPE_CSTRING_UTF32 78
+
+/**
+ * The entry value is of type @ref nvtxStringHandle_t returned by
+ * @ref nvtxDomainRegisterString.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_NVTX_REGISTERED_STRING_HANDLE 80
+
+/**
+ * This type marks the union selector member (entry index) in schemas used by
+ * a union with internal selector.
+ * See @ref NVTX_PAYLOAD_SCHEMA_TYPE_UNION_WITH_INTERNAL_SELECTOR.
+ */
+#define NVTX_PAYLOAD_ENTRY_TYPE_UNION_SELECTOR 100
+
+/**
+ * \brief Predefined schema ID for payload data that is referenced in another payload.
+ *
+ * This schema ID can be used in @ref nvtxPayloadData_t::schema_id to indicate that the
+ * payload is a blob of memory which other payload entries may point into.
+ * A tool will not expose this payload directly.
+ *
+ * This schema ID cannot be used as schema entry type!
+ */
+#define NVTX_TYPE_PAYLOAD_SCHEMA_REFERENCED 1022
+
+/**
+ * \brief Predefined schema ID for raw payload data.
+ *
+ * This schema ID can be used in @ref nvtxPayloadData_t::schema_id to indicate
+ * that the payload is a blob, which can be shown with an arbitrary data viewer.
+ * This schema ID cannot be used as schema entry type!
+ */
+#define NVTX_TYPE_PAYLOAD_SCHEMA_RAW        1023
+
+/* Custom (static) schema IDs. */
+#define NVTX_PAYLOAD_SCHEMA_ID_STATIC_START  (1 << 24)
+
+/* Dynamic schema IDs (generated by the tool) start here. */
+#define NVTX_PAYLOAD_SCHEMA_ID_DYNAMIC_START (NVTX_STATIC_CAST(uint64_t, 1) << 32)
+
+#endif /* NVTX_PAYLOAD_ENTRY_TYPES_V1 */
+/** ---------------------------------------------------------------------------
+ * END: Payload schema entry types.
+ * ------------------------------------------------------------------------- */
+
+
+#ifndef NVTX_PAYLOAD_SCHEMA_TYPES_V1
+#define NVTX_PAYLOAD_SCHEMA_TYPES_V1
+
+/**
+ * \brief The payload schema type.
+ *
+ * A schema can be either of the following types. It is set with
+ * @ref nvtxPayloadSchemaAttr_t::type.
+ */
+#define NVTX_PAYLOAD_SCHEMA_TYPE_INVALID                      0
+#define NVTX_PAYLOAD_SCHEMA_TYPE_STATIC                       1
+#define NVTX_PAYLOAD_SCHEMA_TYPE_DYNAMIC                      2
+#define NVTX_PAYLOAD_SCHEMA_TYPE_UNION                        3
+#define NVTX_PAYLOAD_SCHEMA_TYPE_UNION_WITH_INTERNAL_SELECTOR 4
+
+#endif /* NVTX_PAYLOAD_SCHEMA_TYPES_V1 */
+
+
+#ifndef NVTX_PAYLOAD_SCHEMA_FLAGS_V1
+#define NVTX_PAYLOAD_SCHEMA_FLAGS_V1
+
+/**
+ * \brief Flags for static and dynamic schemas.
+ *
+ * The schema flags are used with @ref nvtxPayloadSchemaAttr_t::flags.
+ */
+#define NVTX_PAYLOAD_SCHEMA_FLAG_NONE           0
+
+/**
+ * This flag indicates that a schema and the corresponding payloads can
+ * contain fields which require a deep copy.
+ */
+#define NVTX_PAYLOAD_SCHEMA_FLAG_DEEP_COPY      (1 << 1)
+
+/**
+ * This flag indicates that a schema and the corresponding payload can be
+ * referenced by another payload of the same event. If the schema is not
+ * intended to be visualized directly, it is possible use
+ * @ref NVTX_TYPE_PAYLOAD_SCHEMA_REFERENCED instead.
+ */
+#define NVTX_PAYLOAD_SCHEMA_FLAG_REFERENCED     (1 << 2)
+
+/**
+ * The schema defines a counter group. An NVTX handler can expect that the schema
+ * contains entries with counter semantics.
+ */
+#define NVTX_PAYLOAD_SCHEMA_FLAG_COUNTER_GROUP  (1 << 3)
+
+/**
+ * The schema defines a range or marker. An NVTX handler can expect that the
+ * schema contains a message and timestamp(s).
+ */
+#define NVTX_PAYLOAD_SCHEMA_FLAG_RANGE_PUSHPOP  (2 << 3)
+#define NVTX_PAYLOAD_SCHEMA_FLAG_RANGE_STARTEND (3 << 3)
+#define NVTX_PAYLOAD_SCHEMA_FLAG_MARK           (4 << 3)
+
+#endif /* NVTX_PAYLOAD_SCHEMA_FLAGS_V1 */
+
+
+#ifndef NVTX_PAYLOAD_SCHEMA_ATTR_FIELDS_V1
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELDS_V1
+
+/**
+ * The values allow the valid fields in @ref nvtxPayloadSchemaAttr_t to be
+ * specified via setting the field `fieldMask`.
+ */
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME        (1 << 1)
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE        (1 << 2)
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_FLAGS       (1 << 3)
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES     (1 << 4)
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES (1 << 5)
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE (1 << 6)
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ALIGNMENT   (1 << 7)
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID   (1 << 8)
+#define NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_EXTENSION   (1 << 9)
+
+#endif /* NVTX_PAYLOAD_SCHEMA_ATTR_FIELDS_V1 */
+
+
+#ifndef NVTX_PAYLOAD_ENUM_ATTR_FIELDS_V1
+#define NVTX_PAYLOAD_ENUM_ATTR_FIELDS_V1
+
+/**
+ * The values are used to set the field `fieldMask` and specify which fields in
+ * @ref nvtxPayloadEnumAttr_t are set.
+ */
+#define NVTX_PAYLOAD_ENUM_ATTR_FIELD_NAME        (1 << 1)
+#define NVTX_PAYLOAD_ENUM_ATTR_FIELD_ENTRIES     (1 << 2)
+#define NVTX_PAYLOAD_ENUM_ATTR_FIELD_NUM_ENTRIES (1 << 3)
+#define NVTX_PAYLOAD_ENUM_ATTR_FIELD_SIZE        (1 << 4)
+#define NVTX_PAYLOAD_ENUM_ATTR_FIELD_SCHEMA_ID   (1 << 5)
+#define NVTX_PAYLOAD_ENUM_ATTR_FIELD_EXTENSION   (1 << 6)
+
+#endif /* NVTX_PAYLOAD_ENUM_ATTR_FIELDS_V1 */
+
+/**
+ * An NVTX scope specifies the execution scope or source of events or counters.
+ * A tool determines the value for a predefined scope when the sample is taken.
+ */
+#ifndef NVTX_SCOPES_V1
+#define NVTX_SCOPES_V1
+
+#define NVTX_SCOPE_NONE                    0 /* No scope specified. */
+#define NVTX_SCOPE_ROOT                    1 /* The root in a hierarchy. */
+
+/* Hardware events */
+#define NVTX_SCOPE_CURRENT_HW_MACHINE      2 /* Node/machine name */
+#define NVTX_SCOPE_CURRENT_HW_SOCKET       3
+#define NVTX_SCOPE_CURRENT_HW_CPU_PHYSICAL 4 /* Physical CPU core */
+#define NVTX_SCOPE_CURRENT_HW_CPU_LOGICAL  5 /* Logical CPU core */
+/* Innermost HW execution context */
+#define NVTX_SCOPE_CURRENT_HW_INNERMOST   15
+
+/* Virtualized hardware, virtual machines */
+#define NVTX_SCOPE_CURRENT_HYPERVISOR     16
+#define NVTX_SCOPE_CURRENT_VM             17
+#define NVTX_SCOPE_CURRENT_KERNEL         18
+#define NVTX_SCOPE_CURRENT_CONTAINER      19
+#define NVTX_SCOPE_CURRENT_OS             20
+
+/* Software scopes */
+#define NVTX_SCOPE_CURRENT_SW_PROCESS     21 /* Process scope */
+#define NVTX_SCOPE_CURRENT_SW_THREAD      22 /* Thread scope */
+/* Innermost SW execution context */
+#define NVTX_SCOPE_CURRENT_SW_INNERMOST   31
+
+/** Static (user-provided) scope IDs (feed forward) */
+#define NVTX_SCOPE_ID_STATIC_START  (1 << 24)
+
+/* Dynamically (tool) generated scope IDs */
+#define NVTX_SCOPE_ID_DYNAMIC_START (NVTX_STATIC_CAST(uint64_t, 1) << 32)
+
+#endif /* NVTX_SCOPES_V1 */
+
+#ifndef NVTX_TIME_V1
+#define NVTX_TIME_V1
+
+/**
+ * Timestamp source is not known, e.g. NIC or switch. The NVTX handler can
+ * assume that at least two synchronization points are created with NVTX
+ * instrumentation.
+ */
+#define NVTX_TIMESTAMP_TYPE_NONE  0
+
+/** The timestamp was provided by the NVTX handler via `nvtxTimestampGet()`. */
+#define NVTX_TIMESTAMP_TYPE_TOOL_PROVIDED  1
+
+/** CPU timestamp sources */
+#define NVTX_TIMESTAMP_TYPE_CPU_TSC  /* RDTSC on x86, CNTVCT on ARM */ 10
+#define NVTX_TIMESTAMP_TYPE_CPU_TSC_NONVIRTUALIZED /* CNTPCT on ARM */ 11
+#define NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_REALTIME                 12
+#define NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_REALTIME_COARSE          13
+#define NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_MONOTONIC                14
+#define NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_MONOTONIC_RAW            15
+#define NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_MONOTONIC_COARSE         16
+#define NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_BOOTTIME                 17
+#define NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_PROCESS_CPUTIME_ID       18
+#define NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_THREAD_CPUTIME_ID        19
+
+#define NVTX_TIMESTAMP_TYPE_WIN_QPC      30
+#define NVTX_TIMESTAMP_TYPE_WIN_GSTAFT   31
+#define NVTX_TIMESTAMP_TYPE_WIN_GSTAFTP  32
+
+#define NVTX_TIMESTAMP_TYPE_C_TIME          40
+#define NVTX_TIMESTAMP_TYPE_C_CLOCK         41
+#define NVTX_TIMESTAMP_TYPE_C_TIMESPEC_GET  42
+
+#define NVTX_TIMESTAMP_TYPE_CPP_STEADY_CLOCK           50
+#define NVTX_TIMESTAMP_TYPE_CPP_HIGH_RESOLUTION_CLOCK  51
+#define NVTX_TIMESTAMP_TYPE_CPP_SYSTEM_CLOCK           52
+#define NVTX_TIMESTAMP_TYPE_CPP_UTC_CLOCK              53
+#define NVTX_TIMESTAMP_TYPE_CPP_TAI_CLOCK              54
+#define NVTX_TIMESTAMP_TYPE_CPP_GPS_CLOCK              55
+#define NVTX_TIMESTAMP_TYPE_CPP_FILE_CLOCK             56
+
+/** GPU timestamp sources */
+#define NVTX_TIMESTAMP_TYPE_GPU_GLOBALTIMER  80 /* e.g. PTIMER */
+
+/** Returned by `nvtxTimeDomainRegister` if time domain registration failed. */
+#define NVTX_TIME_DOMAIN_ID_NONE 0
+
+/** Static (user-provided) time domain IDs (feed forward) */
+#define NVTX_TIME_DOMAIN_ID_STATIC_START  (1 << 24)
+
+/* Dynamically (tool) generated time domain IDs */
+#define NVTX_TIME_DOMAIN_ID_DYNAMIC_START (NVTX_STATIC_CAST(uint64_t, 1) << 32)
+
+/** Timer properties */
+#define NVTX_TIMER_FLAG_NONE             0
+#define NVTX_TIMER_FLAG_CLOCK_MONOTONIC  (1 << 1)
+#define NVTX_TIMER_FLAG_CLOCK_STEADY     (1 << 2)
+
+/** Point in time when the timer starts (its value is 0). */
+#define NVTX_TIMER_START_UNKNOWN         0
+#define NVTX_TIMER_START_SYSTEM_BOOT     1
+#define NVTX_TIMER_START_VM_BOOT         2
+#define NVTX_TIMER_START_UNIX_EPOCH      3 /* 1 January 1970 */
+#define NVTX_TIMER_START_WIN_FILETIME    4 /* 1 January 1601 */
+
+/**
+ * Flags specifying whether it is safe or unsafe to call the timestamp
+ * provider after process teardown.
+ */
+#define NVTX_TIMER_SOURCE_SAFE_CALL_AFTER_PROCESS_TEARDOWN   0
+#define NVTX_TIMER_SOURCE_UNSAFE_CALL_AFTER_PROCESS_TEARDOWN 1
+
+#endif /* NVTX_TIME_V1 */
+
+#ifndef NVTX_BATCH_FLAGS_V1
+#define NVTX_BATCH_FLAGS_V1
+
+/**
+ * Timestamp ordering flags for a batch of deferred events or counters.
+ * By default, chronological order by the first timestamp of the event or
+ * counter is assumed.
+ */
+#define NVTX_BATCH_FLAG_TIME_SORTED            0
+#define NVTX_BATCH_FLAG_TIME_SORTED_PARTIALLY  (1 << 1)
+#define NVTX_BATCH_FLAG_TIME_SORTED_PER_SCOPE  (2 << 1)
+#define NVTX_BATCH_FLAG_UNSORTED               (3 << 1)
+
+#endif /* NVTX_BATCH_FLAGS_V1 */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifndef NVTX_PAYLOAD_TYPEDEFS_V1
+#define NVTX_PAYLOAD_TYPEDEFS_V1
+
+/**
+ * \brief Size and alignment information for predefined payload entry types.
+ *
+ * The struct contains the size and the alignment size in bytes. A respective
+ * array for the predefined types is passed via nvtxExtModuleInfo_t to the NVTX
+ * client/handler. The type (ID) is used as index into this array.
+ */
+typedef struct nvtxPayloadEntryTypeInfo_v1
+{
+    uint16_t size;
+    uint16_t align;
+} nvtxPayloadEntryTypeInfo_t;
+
+/**
+ * \brief Binary payload data, size and decoding information.
+ *
+ * An array of type `nvtxPayloadData_t` is passed to the NVTX event attached to
+ * an NVTX event via the `payload.ullvalue` field of NVTX event attributes.
+ *
+ * The `schemaId` be a predefined schema entry type (`NVTX_PAYLOAD_ENTRY_TYPE*`),
+ * a schema ID (statically specified or dynamically created) or one of
+ * `NVTX_PAYLOAD_TYPE_REFERENCED` or `NVTX_PAYLOAD_TYPE_RAW`.
+ *
+ * Setting the size of a payload to `MAX_SIZE` can be useful to reduce the
+ * overhead of NVTX instrumentation, when no NVTX handler is attached. However,
+ * a tool might not be able to detect the size of a payload and thus skip it.
+ * A reasonable use case is a payload that represents a null-terminated
+ * C string, where the NVTX handler can call `strlen()`.
+ */
+typedef struct nvtxPayloadData_v1
+{
+    /**
+     * The schema ID, which defines the layout of the binary data.
+     */
+    uint64_t    schemaId;
+
+    /**
+     * Size of the payload (blob) in bytes. `SIZE_MAX` (`-1`) indicates the tool
+     * that it should figure out the size, which might not be possible.
+     */
+    size_t      size;
+
+    /**
+     * Pointer to the binary payload data.
+     */
+    const void* payload;
+} nvtxPayloadData_t;
+
+
+/**
+ * \brief Header of the payload entry's semantic field.
+ *
+ * If the semantic field of the payload schema entry is set, the first four
+ * fields (header) are defined with this type. A tool can iterate through the
+ * extensions and check, if it supports (can handle) it.
+ */
+typedef struct nvtxSemanticsHeader_v1
+{
+    uint32_t structSize; /** Size of semantic extension struct. */
+    uint16_t semanticId;
+    uint16_t version;
+    const struct nvtxSemanticsHeader_v1* next; /** linked list */
+    /* Additional fields are defined by the specific semantic extension. */
+} nvtxSemanticsHeader_t;
+
+/**
+ * \brief Entry in a schema.
+ *
+ * A payload schema consists of an array of payload schema entries. It is
+ * registered with @ref nvtxPayloadSchemaRegister. `flag` can be set to `0` for
+ * simple values, 'type' is the only "required" field. If not set explicitly,
+ * all other fields are zero-initialized, which means that the entry has no name
+ * and the offset is determined based on self-alignment rules.
+ *
+ * Example schema:
+ *  nvtxPayloadSchemaEntry_t schema[] = {
+ *      {0, NVTX_EXT_PAYLOAD_TYPE_UINT8, "one byte"},
+ *      {0, NVTX_EXT_PAYLOAD_TYPE_INT32, "four bytes"}
+ *  };
+ */
+typedef struct nvtxPayloadSchemaEntry_v1
+{
+    /**
+     * \brief Flags to augment the basic type.
+     *
+     * This field allows additional properties of the payload entry to be
+     * specified. Valid values are `NVTX_PAYLOAD_ENTRY_FLAG_*`.
+     */
+    uint64_t       flags;
+
+    /**
+     * \brief Predefined payload schema entry type or custom schema ID.
+     *
+     * Predefined types are `NVTX_PAYLOAD_ENTRY_TYPE_*`. Passing a schema ID
+     * enables nesting of schemas.
+     */
+    uint64_t       type;
+
+    /**
+     * \brief Name or label of the payload entry. (Optional)
+     *
+     * A meaningful name or label can help organizing and interpreting the data.
+     */
+    const char*    name;
+
+    /**
+     * \brief Description of the payload entry. (Optional)
+     *
+     * A more detail description of the data that is stored with this entry.
+     */
+    const char*    description;
+
+    /**
+     * \brief String length, array length or member selector for union types.
+     *
+     * If @ref type is a C string type, this field specifies the string length.
+     *
+     * If @ref flags specify that the entry is an array, this field specifies
+     * the array length. See `NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_*` for more details.
+     *
+     * If @ref type is a union with schema type @ref NVTX_PAYLOAD_SCHEMA_TYPE_UNION
+     * (external selection of the union member), this field contains the index
+     * (starting with 0) to an entry of integral type in the same schema. The
+     * associated field value specifies the selected union member.
+     *
+     * @note An array of schema type @ref NVTX_PAYLOAD_SCHEMA_TYPE_UNION is not
+     * supported. @ref NVTX_PAYLOAD_SCHEMA_TYPE_UNION_WITH_INTERNAL_SELECTOR can
+     * be used instead.
+     */
+    uint64_t       arrayOrUnionDetail;
+
+    /**
+     * \brief Offset in the binary payload data (in bytes).
+     *
+     * This field specifies the byte offset from the base address of the actual
+     * binary data (blob) to the start address of the data of this entry.
+     *
+     * It is recommended (but not required) to provide the offset it. Otherwise,
+     * the NVTX handler will determine the offset from natural alignment rules.
+     * In some cases, e.g. dynamic schema layouts, the offset cannot be set and
+     * has to be determined based on the data of prior entries.
+     *
+     * Setting the offset can also be used to skip entries during payload parsing.
+     */
+    uint64_t       offset;
+
+    /**
+     * \brief Additional semantics of the payload entry.
+     *
+     * The field points to the first element in a linked list, which enables
+     * multiple semantic extensions.
+     */
+    const nvtxSemanticsHeader_t* semantics;
+
+    /**
+     * \brief Reserved for future use. Do not use it!
+     */
+    const void*    reserved;
+} nvtxPayloadSchemaEntry_t;
+
+/**
+ * \brief NVTX payload schema attributes.
+ */
+typedef struct nvtxPayloadSchemaAttr_v1
+{
+    /**
+     * \brief Mask of valid fields in this struct.
+     *
+     * Use the `NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_*` defines.
+     */
+    uint64_t                        fieldMask;
+
+    /**
+     * \brief Name of the payload schema. (Optional)
+     */
+    const char*                     name;
+
+    /**
+     * \brief Payload schema type. (Mandatory) \anchor PAYLOAD_TYPE_FIELD
+     *
+     * Use the `NVTX_PAYLOAD_SCHEMA_TYPE_*` defines.
+     */
+    uint64_t                        type;
+
+    /**
+     * \brief Payload schema flags. (Optional)
+     *
+     * Flags defined by `NVTX_PAYLOAD_SCHEMA_FLAG_*` can be used to set
+     * additional properties of the schema.
+     */
+    uint64_t                        flags;
+
+    /**
+     * \brief Entries of a payload schema. (Mandatory) \anchor ENTRIES_FIELD
+     *
+     * This field is a pointer to an array of schema entries, each describing a
+     * field in a data structure, e.g. in a C struct or union.
+     */
+    const nvtxPayloadSchemaEntry_t* entries;
+
+    /**
+     * \brief Number of entries in the payload schema. (Mandatory)
+     *
+     * Number of entries in the array of payload entries \ref ENTRIES_FIELD.
+     */
+    size_t                          numEntries;
+
+    /**
+     * \brief The binary payload size in bytes for static payload schemas.
+     *
+     * If \ref PAYLOAD_TYPE_FIELD is @ref NVTX_PAYLOAD_SCHEMA_TYPE_DYNAMIC this
+     * value is ignored. If this field is not specified for a schema of type
+     * @ref NVTX_PAYLOAD_SCHEMA_TYPE_STATIC, the size can be automatically
+     * determined by a tool.
+     */
+    size_t                          payloadStaticSize;
+
+    /**
+     * \brief The byte alignment for packed structures.
+     *
+     * If not specified, this field defaults to `0`, which means that the fields
+     * in the data structure are not packed and natural alignment rules can be
+     * applied.
+     */
+    size_t                          packAlign;
+
+    /**
+     * A static payload schema ID must be unique within the domain,
+     * >= NVTX_PAYLOAD_SCHEMA_ID_STATIC_START and
+     * < NVTX_PAYLOAD_SCHEMA_ID_DYNAMIC_START
+     */
+    uint64_t                        schemaId;
+
+    /**
+     * Flexible extension for schema attributes.
+     * (Do not use. Reserved for future use.)
+     */
+    void*                           extension;
+} nvtxPayloadSchemaAttr_t;
+
+/**
+ * \brief This type is used to describe an enumeration.
+ *
+ * Since the value of an enum entry might not be meaningful for the analysis
+ * and/or visualization, a tool can show the name of enum entry instead.
+ *
+ * An array of this struct is passed to @ref nvtxPayloadEnumAttr_t::entries to be
+ * finally registered via @ref nvtxPayloadEnumRegister with the NVTX handler.
+ *
+ * @note EXPERIMENTAL
+ */
+typedef struct nvtxPayloadEnum_v1
+{
+    /**
+     * Name of the enum value.
+     */
+    const char* name;
+
+    /**
+     * Value of the enum entry.
+     */
+    uint64_t    value;
+
+    /**
+     * Indicates that this entry sets a specific set of bits, which can be used
+     * to define bitsets.
+     */
+    int8_t      isFlag;
+} nvtxPayloadEnum_t;
+
+/**
+ * \brief NVTX payload enumeration type attributes.
+ *
+ * A pointer to this struct is passed to @ref nvtxPayloadEnumRegister.
+ */
+typedef struct nvtxPayloadEnumAttr_v1
+{
+    /**
+     * Mask of valid fields in this struct. See `NVTX_PAYLOAD_ENUM_ATTR_FIELD_*`.
+     */
+    uint64_t                 fieldMask;
+
+    /**
+     * Name of the enum. (Optional)
+     */
+    const char*              name;
+
+    /**
+     * Entries of the enum. (Mandatory)
+     */
+    const nvtxPayloadEnum_t* entries;
+
+    /**
+     * Number of entries in the enum. (Mandatory)
+     */
+    size_t                   numEntries;
+
+    /**
+     * Size of enumeration type in bytes
+     */
+    size_t                   sizeOfEnum;
+
+    /**
+     * A static payload schema ID must be unique within the domain,
+     * >= NVTX_PAYLOAD_SCHEMA_ID_STATIC_START and
+     * < NVTX_PAYLOAD_SCHEMA_ID_DYNAMIC_START
+     */
+    uint64_t                 schemaId;
+
+    /**
+     * Flexible extension for enumeration attributes.
+     * (Do not use. Reserved for future use.)
+     */
+    void*                    extension;
+} nvtxPayloadEnumAttr_t;
+
+typedef struct nvtxScopeAttr_v1
+{
+    size_t      structSize;
+
+    /**
+     * Path delimited by '/' characters, relative to @ref parentScope. Leading
+     * slashes are ignored. Nodes in the path may use name[key] syntax to
+     * indicate an array of sibling nodes, which may be combined with other
+     * non-array nodes or different arrays at the same scope. Node names should
+     * be UTF8 printable characters. '\' has to be used to escape '/', '[', and
+     * ']' characters in node names. An empty C string "" and `NULL` are valid
+     * inputs and treated equivalently.
+     *
+     * A GPU can be specified using its:
+     * - Unique identifier (UUID) with "GPU[UUID:#]",
+     * - CUDA device ID (sensitive to CUDA_VISIBLE_DEVICES) with "GPU[CUDAID:#]",
+     * - NVML (nvidia-smi) device ID with "GPU[NVSMI:#]"
+     *
+     * (replace `#` with the actual device ID).
+     * For display purposes, a tool is recommended to show a pretty name.
+     * To clearly identify a GPU, the @ref parentScope should also match
+     * the GPU's execution context.
+     */
+    const char* path;
+
+    /** Identifier of the parent scope, to which `path` is appended. */
+    uint64_t    parentScope;
+
+    /**
+     * Static scope ID. Must be unique within the domain,
+     * >= NVTX_SCOPE_ID_STATIC_START, and < NVTX_SCOPE_ID_DYNAMIC_START.
+     * Use NVTX_SCOPE_NONE to let the tool create a (dynamic) scope ID.
+     */
+    uint64_t    scopeId;
+} nvtxScopeAttr_t;
+
+#endif /* NVTX_PAYLOAD_TYPEDEFS_V1 */
+
+#ifndef NVTX_PAYLOAD_TYPEDEFS_DEFERRED_V1
+#define NVTX_PAYLOAD_TYPEDEFS_DEFERRED_V1
+
+/** Attributes of an NVTX time domain. */
+typedef struct nvtxTimeDomainAttr_v1
+{
+    /** Identifyer of the NVTX scope the time domain is associated with. */
+    uint64_t scopeId;
+
+    /** Predefined `NVTX_TIMESTAMP_TYPE_*`. */
+    uint64_t timestampTypeId;
+
+    /**
+     * Static (feed-forward) time domain ID. `0` makes the tool generate the ID.
+     * The static schema ID must be >= NVTX_TIME_DOMAIN_ID_STATIC_START and
+     * < NVTX_TIME_DOMAIN_ID_DYNAMIC_START
+     */
+    uint64_t timeDomainId;
+
+    /** Properties of the timer (use NVTX_TIMER_FLAG_*). */
+    uint64_t timerFlags;
+
+    /** Ticks per second (0 means unknown). */
+    int64_t  timerResolution;
+
+    /** Point in time when the timer starts (use NVTX_TIMER_START_*). */
+    uint64_t timerStart;
+} nvtxTimeDomainAttr_t;
+
+/** Synchronization point between two time domains. */
+typedef struct nvtxSyncPoint_v1
+{
+    int64_t src;
+    int64_t dst;
+} nvtxSyncPoint_t;
+
+/**
+ * \brief Helper struct to submit a batch of events (marks or ranges).
+ *
+ * By default, events are assumed to be chronologically sorted by the first
+ * timestamp in the event (start time in a range). If the events are not sorted,
+ * the `flags` field must be set accordingly (see `NVTX_BATCH_FLAG_*`).
+ */
+typedef struct nvtxEventBatch_v1
+{
+    /**
+     * Identifier of the data layout of a deferred event in the array of events.
+     * Only layouts with static payload size are allowed. The size of an event
+     * in the array is specified by the static payload size during the schema
+     * registration. The time domain of event timestamps is provided via time
+     * semantics in the schema registration.
+     */
+    uint64_t    eventSchemaId;
+
+    /** Size of the array of deferred events (in bytes). */
+    size_t      size;
+
+    /** Pointer to the array of deferred events. */
+    const void* events;
+
+    /** Scope of all events or counters in the batch. */
+    uint64_t    scope;
+
+    /** Timestamp ordering (sorted, partially sorted, unsorted), etc. */
+    uint64_t    flags;
+
+    /** Flexible data which can be referenced by events in the batch. */
+    const void* flexData;
+
+    /** Size of the flexible data memory blob. */
+    size_t      flexDataSize;
+
+    /**
+     * Offset from the `flexData` pointer to the begin of the flexible data
+     * in bytes.
+     */
+    size_t      flexDataOffset;
+} nvtxEventBatch_t;
+
+#endif /* NVTX_PAYLOAD_TYPEDEFS_DEFERRED_V1 */
+
+#ifndef NVTX_PAYLOAD_API_FUNCTIONS_V1
+#define NVTX_PAYLOAD_API_FUNCTIONS_V1
+
+/**
+ * \brief Register a payload schema.
+ *
+ * @param domain NVTX domain handle.
+ * @param attr NVTX payload schema attributes.
+ */
+NVTX_DECLSPEC uint64_t NVTX_API nvtxPayloadSchemaRegister(
+    nvtxDomainHandle_t domain,
+    const nvtxPayloadSchemaAttr_t* attr);
+
+/**
+ * \brief Register an enumeration type with the payload extension.
+ *
+ * @param domain NVTX domain handle
+ * @param attr NVTX payload enumeration type attributes.
+ */
+NVTX_DECLSPEC uint64_t NVTX_API nvtxPayloadEnumRegister(
+    nvtxDomainHandle_t domain,
+    const nvtxPayloadEnumAttr_t* attr);
+
+/**
+ * \brief Register a scope.
+ *
+ * @param domain NVTX domain handle
+ * @param attr Scope attributes.
+ *
+ * @return an identifier for the scope. If the operation was not successful,
+ * `NVTX_SCOPE_NONE` is returned.
+ */
+NVTX_DECLSPEC uint64_t NVTX_API nvtxScopeRegister(
+    nvtxDomainHandle_t domain,
+    const nvtxScopeAttr_t* attr);
+
+/**
+ * \brief Marks an instantaneous event in the application with the attributes
+ * being passed via the extended payload.
+ *
+ * An NVTX handler can assume that the payload contains the event message.
+ * Otherwise, it might ignore the event.
+ *
+ * @param domain NVTX domain handle
+ * @param payloadData pointer to an array of structured payloads.
+ * @param count number of payload BLOBs.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxMarkPayload(
+    nvtxDomainHandle_t domain,
+    const nvtxPayloadData_t* payloadData,
+    size_t count);
+
+/**
+ * \brief Begin a nested thread range with the attributes being passed via the
+ * payload.
+ *
+ * @param domain NVTX domain handle
+ * @param payloadData Pointer to an array of extended payloads.
+ * @param count Number of payloads.
+ *
+ * @return The level of the range being ended. If an error occurs a negative
+ * value is returned on the current thread.
+ */
+NVTX_DECLSPEC int NVTX_API nvtxRangePushPayload(
+    nvtxDomainHandle_t domain,
+    const nvtxPayloadData_t* payloadData,
+    size_t count);
+
+/**
+ * \brief End a nested thread range with an additional custom payload.
+ *
+ * NVTX event attributes passed to this function (via the payloads) overwrite
+ * event attributes (message and color) that have been set in the push event.
+ * Other payload entries extend the data of the range.
+ *
+ * @param domain NVTX domain handle
+ * @param payloadData pointer to an array of structured payloads.
+ * @param count number of payload BLOBs.
+ *
+ * @return The level of the range being ended. If an error occurs a negative
+ * value is returned on the current thread.
+ */
+NVTX_DECLSPEC int NVTX_API nvtxRangePopPayload(
+    nvtxDomainHandle_t domain,
+    const nvtxPayloadData_t* payloadData,
+    size_t count);
+
+/**
+ * \brief Start a thread range with attributes passed via the extended payload.
+ *
+ * @param domain NVTX domain handle
+ * @param payloadData pointer to an array of structured payloads.
+ * @param count number of payload BLOBs.
+ *
+ * @return The level of the range being ended. If an error occurs a negative
+ * value is returned on the current thread.
+ */
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxRangeStartPayload(
+    nvtxDomainHandle_t domain,
+    const nvtxPayloadData_t* payloadData,
+    size_t count);
+
+/**
+ * \brief End a thread range and pass a custom payload.
+ *
+ * NVTX event attributes passed to this function (via the payloads) overwrite
+ * event attributes (message and color) that have been set in the start event.
+ * Other payload entries extend the data of the range.
+ *
+ * @param domain NVTX domain handle
+ * @param id The correlation ID returned from a NVTX range start call.
+ * @param payloadData pointer to an array of structured payloads.
+ * @param count number of payload BLOBs.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxRangeEndPayload(
+    nvtxDomainHandle_t domain,
+    nvtxRangeId_t id,
+    const nvtxPayloadData_t* payloadData,
+    size_t count);
+
+/**
+ * \brief Checks if the given NVTX domain is enabled.
+ *
+ * This function can be used to guard expensive code instrumentation.
+ * In general, it is recommended to avoid different execution branches based on
+ * NVTX instrumenation.
+ *
+ * If no tool is attached, this function will always return `0`.
+ * If a tool is attached, but does not handle this function, `1` is returned.
+ * If a tool is attached and handles this function, the return value is
+ * determined by the tool. Positive (>0) return values indicate that the domain
+ * is enabled, `0` indicates that the domain is disabled.
+ *
+ * @param domain NVTX domain handle
+ * @return 0 if the domain is disabled. Values > 0 indicate an enabled domain.
+ */
+NVTX_DECLSPEC uint8_t NVTX_API nvtxDomainIsEnabled(
+    nvtxDomainHandle_t domain);
+
+#endif /* NVTX_PAYLOAD_API_FUNCTIONS_V1 */
+
+#ifndef NVTX_PAYLOAD_API_FUNCTIONS_DEFERRED_V1
+#define NVTX_PAYLOAD_API_FUNCTIONS_DEFERRED_V1
+
+/**
+ * Get a timestamp from the NVTX handler or tool. If no tool is attached, the
+ * CPU TSC might be returned. No guarantees are made.
+ * The returned timestamp is just meant to be used in deferred events/counters.
+ */
+NVTX_DECLSPEC int64_t NVTX_API nvtxTimestampGet(void);
+
+/**
+ * Register a time domain. Associates an NVTX scope with the time domain.
+ * Timestamps of NVTX events or counters in the scope are interpreted according
+ * to the time domain definitions.
+ *
+ * @param domain NVTX domain handle.
+ * @param timeAttr Time domain attributes (timestamp type, scope, flags, etc.).
+ * @return time domain ID.
+ */
+NVTX_DECLSPEC uint64_t NVTX_API nvtxTimeDomainRegister(
+    nvtxDomainHandle_t domain,
+    const nvtxTimeDomainAttr_t* timeAttr);
+
+/**
+ * Provide the pointer to a function that returns a timestamp.
+ * This enables the tool to create time synchronization points.
+ *
+ * @param domain NVTX domain handle.
+ * @param timeDomainId time domain identifier or timestamp type ID, if it is
+ *                     unambiguous.
+ * @param flags indicates if it is safe to call the timestamp provider after
+ *             process teardown.
+ * @param timestampProviderFn Pointer to a function that returns a timestamp.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxTimerSource(
+    nvtxDomainHandle_t domain,
+    uint64_t timeDomainId,
+    uint64_t flags,
+    int64_t (*timestampProviderFn)(void));
+
+/**
+ * Same as `nvtxTimerSource`, but with an additional data pointer argument.
+ *
+ * @param domain NVTX domain handle.
+ * @param timeDomainId time domain identifier or timestamp type ID, if it is
+ *                     unambiguous.
+ * @param flags indicates if it is safe to call the timestamp provider after
+ *             process teardown.
+ * @param timestampProviderFn Pointer to a function that returns a timestamp.
+ * @param data Pointer to data that is passed to the timestamp provider function.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxTimerSourceWithData(
+    nvtxDomainHandle_t domain,
+    uint64_t timeDomainId,
+    uint64_t flags,
+    int64_t (*timestampProviderFn)(void* data),
+    void* data);
+
+/**
+ * Provides a synchronization point between two time domains.
+ * Two synchronization points are required to enable a timestamp conversion.
+ * The tool must know one of the time domains or it least must be able to chain
+ * conversions to enable the conversion between the given timestamps.
+ *
+ * @param domain NVTX domain handle.
+ * @param timeDomainId1 time domain 1 ID or timestamp type ID, if it is
+ *                      unambiguous.
+ * @param timeDomainId2 time domain 2 ID or timestamp type ID, if it is
+ *                      unambiguous.
+ * @param timestamp1 Timestamp in the first time domain.
+ * @param timestamp2 Timestamp in the second time domain.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxTimeSyncPoint(
+    nvtxDomainHandle_t domain,
+    uint64_t timeDomainId1,
+    uint64_t timeDomainId2,
+    int64_t timestamp1,
+    int64_t timestamp2);
+
+/**
+ * The same as `nvtxTimeSyncPoint` but with multiple synchronization points.
+ *
+ * @param domain NVTX domain handle.
+ * @param timeDomainIdSrc source time domain ID or timestamp type ID, if it is
+ *                        unambiguous.
+ * @param timeDomainIdDst destination time domain ID or timestamp type ID, if it
+ *                        is unambiguous.
+ * @param syncPoints Pointer to an array of synchronization points.
+ * @param count Number of synchronization points.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxTimeSyncPointTable(
+    nvtxDomainHandle_t domain,
+    uint64_t timeDomainIdSrc,
+    uint64_t timeDomainIdDst,
+    const nvtxSyncPoint_t* syncPoints,
+    size_t count);
+
+/**
+ * @brief Pass a conversion factor between two time domains to the NVTX handler.
+ *
+ * @param domain NVTX domain handle.
+ * @param timeDomainIdSrc source time domain ID or timestamp type ID, if it is
+ *                        unambiguous.
+ * @param timeDomainIdDst destination time domain ID or timestamp type ID, if it
+ *                        is unambiguous.
+ * @param slope Conversion factor between the two time domains.
+ * @param timestampSrc Timestamp in the source time domain.
+ * @param timestampDst Timestamp in the destination time domain.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxTimestampConversionFactor(
+    nvtxDomainHandle_t domain,
+    uint64_t timeDomainIdSrc,
+    uint64_t timeDomainIdDst,
+    double slope,
+    int64_t timestampSrc,
+    int64_t timestampDst);
+
+/**
+ * @brief Submit one deferred event.
+ *
+ * @param domain NVTX domain handle.
+ * @param payloadData Pointer to an array of structured payloads.
+ * @param numPayloads Number of payloads of the event.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxEventSubmit(
+    nvtxDomainHandle_t domain,
+    const nvtxPayloadData_t* payloadData,
+    size_t numPayloads);
+
+/**
+ * \brief Submit a batch of deferred events in the given domain.
+ *
+ * @param domain NVTX domain handle.
+ * @param eventBatch Pointer to deferred events batch details.
+ */
+NVTX_DECLSPEC void NVTX_API nvtxEventBatchSubmit(
+    nvtxDomainHandle_t domain,
+    const nvtxEventBatch_t* eventBatch);
+
+#endif /* NVTX_PAYLOAD_API_FUNCTIONS_DEFERRED_V1 */
+
+/**
+ * \brief Callback IDs of API functions in the payload extension.
+ *
+ * The NVTX handler can use these values to register a handler function. When
+ * `InitializeInjectionNvtxExtension(nvtxExtModuleInfo_t* moduleInfo)` is
+ * executed, a handler routine can be registered as follows:
+ * \code{.c}
+ *      moduleInfo->segments->slots[NVTX3EXT_CBID_nvtxPayloadSchemaRegister] =
+ *          (intptr_t)PayloadSchemaRegisterHandlerFn;
+ * \endcode
+ */
+#ifndef NVTX_PAYLOAD_CALLBACK_ID_V1
+#define NVTX_PAYLOAD_CALLBACK_ID_V1
+
+#define NVTX3EXT_CBID_nvtxPayloadSchemaRegister      0
+#define NVTX3EXT_CBID_nvtxPayloadEnumRegister        1
+#define NVTX3EXT_CBID_nvtxMarkPayload                2
+#define NVTX3EXT_CBID_nvtxRangePushPayload           3
+#define NVTX3EXT_CBID_nvtxRangePopPayload            4
+#define NVTX3EXT_CBID_nvtxRangeStartPayload          5
+#define NVTX3EXT_CBID_nvtxRangeEndPayload            6
+#define NVTX3EXT_CBID_nvtxDomainIsEnabled            7
+#define NVTX3EXT_CBID_nvtxScopeRegister             12
+
+#endif /* NVTX_PAYLOAD_CALLBACK_ID_V1 */
+
+#ifndef NVTX_PAYLOAD_CALLBACK_ID_DEFERRED_V1
+#define NVTX_PAYLOAD_CALLBACK_ID_DEFERRED_V1
+
+#define NVTX3EXT_CBID_nvtxTimestampGet               8
+#define NVTX3EXT_CBID_nvtxTimeDomainRegister         9
+#define NVTX3EXT_CBID_nvtxTimerSource               10
+#define NVTX3EXT_CBID_nvtxTimerSourceWithData       11
+#define NVTX3EXT_CBID_nvtxTimeSyncPoint             13
+#define NVTX3EXT_CBID_nvtxTimeSyncPointTable        14
+#define NVTX3EXT_CBID_nvtxTimestampConversionFactor 15
+#define NVTX3EXT_CBID_nvtxEventSubmit               16
+#define NVTX3EXT_CBID_nvtxEventBatchSubmit          17
+
+#endif /* NVTX_PAYLOAD_CALLBACK_ID_DEFERRED_V1 */
+
+/*** Helper utilities ***/
+
+/** \brief  Helper macro for safe double-cast of pointer to uint64_t value. */
+#ifndef NVTX_POINTER_AS_PAYLOAD_ULLVALUE
+# ifdef __cplusplus
+# define NVTX_POINTER_AS_PAYLOAD_ULLVALUE(p) \
+    static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p))
+# else
+#define NVTX_POINTER_AS_PAYLOAD_ULLVALUE(p) (NVTX_STATIC_CAST(uint64_t, NVTX_STATIC_CAST(uintptr_t, p))
+# endif
+#endif
+
+#ifndef NVTX_PAYLOAD_EVTATTR_SET_DATA
+/**
+ * \brief Helper macro to attach a single payload to an NVTX event attribute.
+ *
+ * @param evtAttr NVTX event attribute (variable name)
+ * @param pldata_addr Address of `nvtxPayloadData_t` variable.
+ * @param schema_id NVTX binary payload schema ID.
+ * @param pl_addr Address of the (actual) payload.
+ * @param sz size of the (actual) payload.
+ */
+#define NVTX_PAYLOAD_EVTATTR_SET_DATA(evtAttr, pldata_addr, schema_id, pl_addr, sz) \
+    (pldata_addr)->schemaId = schema_id; \
+    (pldata_addr)->size = sz; \
+    (pldata_addr)->payload = pl_addr; \
+    (evtAttr).payload.ullValue = NVTX_POINTER_AS_PAYLOAD_ULLVALUE(pldata_addr); \
+    (evtAttr).payloadType = NVTX_PAYLOAD_TYPE_EXT; \
+    (evtAttr).reserved0 = 1;
+#endif /* NVTX_PAYLOAD_EVTATTR_SET_DATA */
+
+#ifndef NVTX_PAYLOAD_EVTATTR_SET_MULTIPLE
+/**
+ * \brief Helper macro to attach multiple payloads to an NVTX event attribute.
+ *
+ * @param evtAttr NVTX event attribute (variable name)
+ * @param pldata Payload data array (of type `nvtxPayloadData_t`)
+ */
+#define NVTX_PAYLOAD_EVTATTR_SET_MULTIPLE(evtAttr, pldata) \
+    (evtAttr).payloadType = NVTX_PAYLOAD_TYPE_EXT; \
+    (evtAttr).reserved0 = sizeof(pldata)/sizeof(nvtxPayloadData_t); \
+    (evtAttr).payload.ullValue = NVTX_POINTER_AS_PAYLOAD_ULLVALUE(pldata);
+#endif /* NVTX_PAYLOAD_EVTATTR_SET_MULTIPLE */
+
+#ifndef NVTX_PAYLOAD_EVTATTR_SET
+/*
+ * Do not use this macro directly! It is a helper to attach a single payload to
+ * an NVTX event attribute.
+ * @warning The NVTX push, start or mark operation must not be in an outer scope.
+ */
+#define NVTX_PAYLOAD_EVTATTR_SET(evtAttr, schema_id, pl_addr, sz) \
+    nvtxPayloadData_t _NVTX_PAYLOAD_DATA_VAR[] = \
+        {{schema_id, sz, pl_addr}}; \
+    (evtAttr)->payload.ullValue = \
+        NVTX_POINTER_AS_PAYLOAD_ULLVALUE(_NVTX_PAYLOAD_DATA_VAR); \
+    (evtAttr)->payloadType = NVTX_PAYLOAD_TYPE_EXT; \
+    (evtAttr)->reserved0 = 1;
+#endif /* NVTX_PAYLOAD_EVTATTR_SET */
+
+#ifndef nvtxPayloadRangePush
+/**
+ * \brief Helper macro to push a range with extended payload.
+ *
+ * @param domain NVTX domain handle
+ * @param evtAttr pointer to NVTX event attribute.
+ * @param schemaId NVTX payload schema ID
+ * @param plAddr Pointer to the binary data (actual payload)
+ * @param size Size of the binary payload data in bytes.
+ */
+#define nvtxPayloadRangePush(domain, evtAttr, schemaId, plAddr, size) \
+do { \
+    NVTX_PAYLOAD_EVTATTR_SET(evtAttr, schemaId, plAddr, size) \
+    nvtxDomainRangePushEx(domain, evtAttr); \
+} while (0)
+#endif /* nvtxPayloadRangePush */
+
+#ifndef nvtxPayloadMark
+/**
+ * \brief Helper macro to set a marker with extended payload.
+ *
+ * @param domain NVTX domain handle
+ * @param evtAttr pointer to NVTX event attribute.
+ * @param schemaId NVTX payload schema ID
+ * @param plAddr Pointer to the binary data (actual payload)
+ * @param size Size of the binary payload data in bytes.
+ */
+#define nvtxPayloadMark(domain, evtAttr, schemaId, plAddr, size) \
+do { \
+    NVTX_PAYLOAD_EVTATTR_SET(evtAttr, schemaId, plAddr, size) \
+    nvtxDomainMarkEx(domain, evtAttr); \
+} while (0)
+#endif /* nvtxPayloadMark */
+
+/* Macros to create versioned symbols. */
+#ifndef NVTX_EXT_PAYLOAD_VERSIONED_IDENTIFIERS_V1
+#define NVTX_EXT_PAYLOAD_VERSIONED_IDENTIFIERS_V1
+#define NVTX_EXT_PAYLOAD_VERSIONED_IDENTIFIER_L3(NAME, VERSION, COMPATID) \
+    NAME##_v##VERSION##_bpl##COMPATID
+#define NVTX_EXT_PAYLOAD_VERSIONED_IDENTIFIER_L2(NAME, VERSION, COMPATID) \
+    NVTX_EXT_PAYLOAD_VERSIONED_IDENTIFIER_L3(NAME, VERSION, COMPATID)
+#define NVTX_EXT_PAYLOAD_VERSIONED_ID(NAME) \
+    NVTX_EXT_PAYLOAD_VERSIONED_IDENTIFIER_L2(NAME, NVTX_VERSION, NVTX_EXT_PAYLOAD_COMPATID)
+#endif /* NVTX_EXT_PAYLOAD_VERSIONED_IDENTIFIERS_V1 */
+
+#ifdef __GNUC__
+#pragma GCC visibility push(internal)
+#endif
+
+/* Extension types are required for the implementation and the NVTX handler. */
+#define NVTX_EXT_TYPES_GUARD
+#include "nvtxDetail/nvtxExtTypes.h"
+#undef NVTX_EXT_TYPES_GUARD
+
+#ifndef NVTX_NO_IMPL
+#define NVTX_EXT_IMPL_PAYLOAD_GUARD
+#include "nvtxDetail/nvtxExtImplPayload_v1.h"
+#undef NVTX_EXT_IMPL_PAYLOAD_GUARD
+#endif /* NVTX_NO_IMPL */
+
+#ifdef __GNUC__
+#pragma GCC visibility pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */

--- a/third_party/nvtx/include/nvtx3/nvToolsExtPayloadHelper.h
+++ b/third_party/nvtx/include/nvtx3/nvToolsExtPayloadHelper.h
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+#include "nvtxDetail/nvtxExtPayloadHelperInternal.h"
+
+
+/* This is just an empty marker (for readability), which can be omitted. */
+/* TODO: Fix issue with trailing comma at end of entry list. */
+#define NVTX_PAYLOAD_ENTRIES
+
+
+/**
+ * Use this macro for payload entries that are defined by a schema (nested
+ * payload schema).
+ */
+#define NVTX_PAYLOAD_NESTED(schemaId) _NVTX_PAYLOAD_NESTED(schemaId)
+
+
+/**
+ * \brief Define a payload schema for an existing C `struct` definition.
+ *
+ *  This macro does
+ *   1) create schema description (array of schema entries).
+ *   2) set the schema attributes for a static data layout.
+ *
+ * It can be used in static code or within a function context.
+ *
+ * Example:
+ *  NVTX_DEFINE_SCHEMA_FOR_STRUCT(your_struct, "SchemaName",
+ *      NVTX_PAYLOAD_ENTRIES(
+ *          (index, TYPE_INT, "integer value"),
+ *          (dpfloat, TYPE_DOUBLE, "fp64 value"),
+ *          (text, TYPE_CSTRING, "text", NULL, 24)
+ *      )
+ *  )
+ *
+ * It is required to at least provide the struct name and the payload entries.
+ * The first two fields (member name and NVTX entry type) of each payload entry
+ * are required.
+ *
+ * The optional parameters are only allowed to be passed in the predefined order.
+ * Hence, `payload_flags` requires `payload_schema` to be given and
+ * `prefix` requires `payload_flags` and `payload_schema` to be given.
+ * The payload entries are always the last parameter. A maximum of 16 schema
+ * entries is supported.
+ *
+ * It is recommended to use `NVTX_PAYLOAD_SCHEMA_REGISTER` to register the schema.
+ *
+ * @param struct_id The name of the struct.
+ * @param schema_name (Optional 1) name of the payload schema. Default is `NULL`.
+ * @param prefix (Optional 2) prefix before the schema and attributes variables,
+ *               e.g. `static const`. Leave this empty, if no prefix is desired.
+ * @param schema_flags (Optional 2) flags to augment the payload schema.
+ *                     Default is `NVTX_PAYLOAD_SCHEMA_FLAG_NONE`.
+ * @param schema_id (Optional 4) User-defined payload schema ID.
+ * @param entries (Mandatory) Payload schema entries. This is always the last
+ *                parameter to the macro.
+ */
+#define NVTX_DEFINE_SCHEMA_FOR_STRUCT(struct_id, ...) \
+    _NVTX_DEFINE_SCHEMA_FOR_STRUCT(struct_id, __VA_ARGS__)
+
+
+/**
+ * \brief Define a C struct together with a matching schema.
+ *
+ * This macro does
+ *   1) define the payload type (typedef struct).
+ *   2) create schema description (array of schema entries).
+ *   3) set the schema attributes for a static data layout.
+ *
+ * The macro can be used in static code or within a function context.
+ *
+ * It defines the schema attributes in `struct_id##Attr`. Thus, it is recommended
+ * to use `NVTX_PAYLOAD_SCHEMA_REGISTER(domain, struct_id)` to register the schema.
+ *
+ * Example:
+ *  NVTX_DEFINE_STRUCT_WITH_SCHEMA(your_struct_name, "Your schema name",
+ *      NVTX_PAYLOAD_ENTRIES(
+ *          (int, index, TYPE_INT, "integer value"),
+ *          (double, dpfloat, TYPE_DOUBLE, "fp64 value"),
+ *          (const char, (text, 24), TYPE_CSTRING, "text", NULL, 24)
+ *      )
+ *  )
+ *
+ * The first three fields (C type, member, entry type) of each entry are required.
+ * A fixed-size array or string requires a special notation with the member
+ * name and the size separated by comma and put into brackets (see last entry
+ * in the example).
+ *
+ * The optional parameters are positional (only allowed to be passed in the
+ * predefined order). A maximum of 16 schema entries is supported.
+ *
+ * @param struct_id The name of the struct.
+ * @param schema_name (Optional 1) name of the payload schema. Default is `NULL`.
+ * @param prefix (Optional 2) prefix before the schema and attributes variables,
+ *               e.g. `static const`. Leave this empty, if no prefix is desired.
+ * @param schema_flags (Optional 3) flags to augment the payload schema.
+ *                     Default is `NVTX_PAYLOAD_SCHEMA_FLAG_NONE`.
+ * @param schema_id (Optional 4) User-defined payload schema ID.
+ * @param entries (Mandatory) The schema entries. This is always the last
+ *                parameter to the macro.
+ */
+#define NVTX_DEFINE_STRUCT_WITH_SCHEMA(struct_id, ...) \
+    _NVTX_DEFINE_STRUCT_WITH_SCHEMA(struct_id, __VA_ARGS__)
+
+/**
+ * \brief Initialize and register the NVTX binary payload schema.
+ *
+ * This does essentially the same as `NVTX_DEFINE_STRUCT_WITH_SCHEMA`, but in
+ * addition the schema is registered. The schema ID will be defined as follows:
+ * `const uint64_t struct_id##_schemaId`.
+ *
+ * @param domain The NVTX domain handle.
+ * All other parameters are similar to `NVTX_DEFINE_STRUCT_WITH_SCHEMA`.
+ */
+#define NVTX_DEFINE_STRUCT_WITH_SCHEMA_AND_REGISTER(domain, struct_id, ...) \
+    _NVTX_DEFINE_STRUCT_WITH_SCHEMA(struct_id, __VA_ARGS__) \
+    const uint64_t struct_id##_schemaId = nvtxPayloadSchemaRegister(domain, &struct_id##Attr);
+
+/**
+ * \brief Define payload schema for an existing `struct` and register the schema.
+ *
+ * This does essentially the same as `NVTX_PAYLOAD_STATIC_SCHEMA_DEFINE`, but in
+ * addition, the schema is registered and `uint64_t struct_id##_schemaId` set.
+ *
+ * @param domain The NVTX domain handle.
+ * All other parameters are similar to `NVTX_PAYLOAD_STATIC_SCHEMA_DEFINE`.
+ */
+#define NVTX_DEFINE_SCHEMA_FOR_STRUCT_AND_REGISTER(domain, struct_id, ...) \
+    _NVTX_DEFINE_SCHEMA_FOR_STRUCT(struct_id, __VA_ARGS__) \
+    const uint64_t struct_id##_schemaId = nvtxPayloadSchemaRegister(domain, &struct_id##Attr);
+
+/**
+ * \brief Create a type definition for the given struct ID and members.
+ *
+ * This is a convenience macro. A normal `typedef` can be used instead.
+ *
+ * Example usage:
+ *   NVTX_DEFINE_STRUCT(your_struct,
+ *           (double, fp64),
+ *           (uint8_t, u8),
+ *           (float, fp32[3])
+ *   )
+ *
+ * @param struct_id The name of the struct.
+ * @param members The members of the struct.
+ */
+#define NVTX_DEFINE_STRUCT(struct_id, ...) \
+    _NVTX_PAYLOAD_TYPEDEF_STRUCT(struct_id, __VA_ARGS__)
+
+/**
+ * \brief Register an NVTX binary payload schema.
+ *
+ * This is a convenience macro, which takes the same `struct_id` that has been
+ * used in other helper macros. Instead, `nvtxPayloadSchemaRegister` can also be
+ * used, but `&struct_id##Attr` has to be passed.
+ *
+ * @param domain The NVTX domain handle.
+ * @param struct_id The name of the struct.
+ *
+ * @return NVTX schema ID
+ */
+#define NVTX_PAYLOAD_SCHEMA_REGISTER(domain, struct_id) \
+    nvtxPayloadSchemaRegister(domain, &struct_id##Attr);

--- a/third_party/nvtx/include/nvtx3/nvtx3.hpp
+++ b/third_party/nvtx/include/nvtx3/nvtx3.hpp
@@ -1,0 +1,3348 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+/* Temporary helper #defines, #undef'ed at end of header */
+#define NVTX3_CPP_VERSION_MAJOR 1
+#define NVTX3_CPP_VERSION_MINOR 1
+
+/* This section handles the decision of whether to provide unversioned symbols.
+ * If NVTX3_CPP_REQUIRE_EXPLICIT_VERSION is #defined, unversioned symbols are
+ * not provided, and explicit-version symbols such as nvtx3::v1::scoped_range
+ * and NVTX3_V1_FUNC_RANGE must be used.  By default, the first #include of this
+ * header will define the unversioned symbols such as nvtx3::scoped_range and
+ * NVTX3_FUNC_RANGE.  Subsequently including a different major version of this
+ * header without #defining NVTX3_CPP_REQUIRE_EXPLICIT_VERSION triggers an error
+ * since the symbols would conflict.  Subsequently including of a different
+ * minor version within the same major version is allowed. Functionality of
+ * minor versions is cumulative, regardless of include order.
+ *
+ * Since NVTX3_CPP_REQUIRE_EXPLICIT_VERSION allows all combinations of versions
+ * to coexist without problems within a translation unit, the recommended best
+ * practice for instrumenting header-based libraries with NVTX C++ Wrappers is
+ * is to #define NVTX3_CPP_REQUIRE_EXPLICIT_VERSION before including nvtx3.hpp,
+ * #undef it afterward, and only use explicit-version symbols.  This is not
+ * necessary in common cases, such as instrumenting a standalone application, or
+ * static/shared libraries in .cpp files or headers private to those projects.
+ */
+/* clang-format off */
+#if !defined(NVTX3_CPP_REQUIRE_EXPLICIT_VERSION)
+  /* Define macro used by all definitions in this header to indicate the
+   * unversioned symbols should be defined in addition to the versioned ones.
+   */
+  #define NVTX3_INLINE_THIS_VERSION
+
+  #if !defined(NVTX3_CPP_INLINED_VERSION_MAJOR)
+    /* First occurrence of this header in the translation unit.  Define macros
+     * indicating which version shall be used for unversioned symbols.
+     */
+
+    /**
+     * @brief Semantic major version number for NVTX C++ wrappers of unversioned symbols
+     *
+     * Breaking changes may occur between major versions, and different major versions
+     * cannot provide unversioned symbols in the same translation unit (.cpp file).
+     *
+     * Note: If NVTX3_CPP_REQUIRE_EXPLICIT_VERSION is defined, this macro is not defined.
+     *
+     * Not to be confused with the version number of the NVTX core library.
+     */
+    #define NVTX3_CPP_INLINED_VERSION_MAJOR 1  // NVTX3_CPP_VERSION_MAJOR
+
+    /**
+     * @brief Semantic minor version number for NVTX C++ wrappers of unversioned symbols
+     *
+     * No breaking changes occur between minor versions -- minor version changes within
+     * a major version are purely additive.
+     *
+     * Note: If NVTX3_CPP_REQUIRE_EXPLICIT_VERSION is defined, this macro is not defined.
+     *
+     * Not to be confused with the version number of the NVTX core library.
+     */
+    #define NVTX3_CPP_INLINED_VERSION_MINOR 1  // NVTX3_CPP_VERSION_MINOR
+  #elif NVTX3_CPP_INLINED_VERSION_MAJOR != NVTX3_CPP_VERSION_MAJOR
+    /* Unsupported case -- cannot define unversioned symbols for different major versions
+     * in the same translation unit.
+     */
+    #error \
+      "Two different major versions of the NVTX C++ Wrappers are being included in a single .cpp file, with unversioned symbols enabled in both.  Only one major version can enable unversioned symbols in a .cpp file.  To disable unversioned symbols, #define NVTX3_CPP_REQUIRE_EXPLICIT_VERSION before #including nvtx3.hpp, and use the explicit-version symbols instead -- this is the preferred way to use nvtx3.hpp from a header file."
+  #elif (NVTX3_CPP_INLINED_VERSION_MAJOR == NVTX3_CPP_VERSION_MAJOR) && \
+    (NVTX3_CPP_INLINED_VERSION_MINOR < NVTX3_CPP_VERSION_MINOR)
+    /* An older minor version of the same major version already defined unversioned
+     * symbols.  The new features provided in this header will be inlined
+     * redefine the minor version macro to this header's version.
+     */
+    #undef NVTX3_CPP_INLINED_VERSION_MINOR
+    #define NVTX3_CPP_INLINED_VERSION_MINOR 1  // NVTX3_CPP_VERSION_MINOR
+    // else, already have this version or newer, nothing to do
+  #endif
+#endif
+/* clang-format on */
+
+/**
+ * @file nvtx3.hpp
+ *
+ * @brief Provides C++ constructs making the NVTX library safer and easier to
+ * use with zero overhead.
+ */
+
+/**
+ * \mainpage
+ * \tableofcontents
+ *
+ * \section QUICK_START Quick Start
+ *
+ * To add NVTX ranges to your code, use the `nvtx3::scoped_range` RAII object. A
+ * range begins when the object is created, and ends when the object is
+ * destroyed.
+ *
+ * \code{.cpp}
+ * #include "nvtx3/nvtx3.hpp"
+ * void some_function() {
+ *    // Begins a NVTX range with the message "some_function"
+ *    // The range ends when some_function() returns and `r` is destroyed
+ *    nvtx3::scoped_range r{"some_function"};
+ *
+ *    for(int i = 0; i < 5; ++i) {
+ *       nvtx3::scoped_range loop{"loop range"};
+ *       std::this_thread::sleep_for(std::chrono::seconds{1});
+ *    }
+ * } // Range ends when `r` is destroyed
+ * \endcode
+ *
+ * The example code above generates the following timeline view in Nsight
+ * Systems:
+ *
+ * \image html https://raw.githubusercontent.com/NVIDIA/NVTX/release-v3/docs/images/example_range.png
+ *
+ * Alternatively, use the \ref MACROS like `NVTX3_FUNC_RANGE()` to add
+ * ranges to your code that automatically use the name of the enclosing function
+ * as the range's message.
+ *
+ * \code{.cpp}
+ * #include "nvtx3/nvtx3.hpp"
+ * void some_function() {
+ *    // Creates a range with a message "some_function" that ends when the
+ *    // enclosing function returns
+ *    NVTX3_FUNC_RANGE();
+ *    ...
+ * }
+ * \endcode
+ *
+ *
+ * \section Overview
+ *
+ * The NVTX library provides a set of functions for users to annotate their code
+ * to aid in performance profiling and optimization. These annotations provide
+ * information to tools like Nsight Systems to improve visualization of
+ * application timelines.
+ *
+ * \ref RANGES are one of the most commonly used NVTX constructs for annotating
+ * a span of time. For example, imagine a user wanted to see every time a
+ * function, `my_function`, is called and how long it takes to execute. This can
+ * be accomplished with an NVTX range created on the entry to the function and
+ * terminated on return from `my_function` using the push/pop C APIs:
+ *
+ * \code{.cpp}
+ * void my_function(...) {
+ *    nvtxRangePushA("my_function"); // Begins NVTX range
+ *    // do work
+ *    nvtxRangePop(); // Ends NVTX range
+ * }
+ * \endcode
+ *
+ * One of the challenges with using the NVTX C API is that it requires manually
+ * terminating the end of the range with `nvtxRangePop`. This can be challenging
+ * if `my_function()` has multiple returns or can throw exceptions as it
+ * requires calling `nvtxRangePop()` before all possible return points.
+ *
+ * NVTX C++ solves this inconvenience through the "RAII" technique by providing
+ * a `nvtx3::scoped_range` class that begins a range at construction and ends
+ * the range on destruction. The above example then becomes:
+ *
+ * \code{.cpp}
+ * void my_function(...) {
+ *    nvtx3::scoped_range r{"my_function"}; // Begins NVTX range
+ *    // do work
+ * } // Range ends on exit from `my_function` when `r` is destroyed
+ * \endcode
+ *
+ * The range object `r` is deterministically destroyed whenever `my_function`
+ * returns---ending the NVTX range without manual intervention. For more
+ * information, see \ref RANGES and `nvtx3::scoped_range_in`.
+ *
+ * Another inconvenience of the NVTX C APIs are the several constructs where the
+ * user is expected to initialize an object at the beginning of an application
+ * and reuse that object throughout the lifetime of the application. For example
+ * see domains, categories, and registered messages.
+ *
+ * Example:
+ * \code{.cpp}
+ * nvtxDomainHandle_t D = nvtxDomainCreateA("my domain");
+ * // Reuse `D` throughout the rest of the application
+ * \endcode
+ *
+ * This can be problematic if the user application or library does not have an
+ * explicit initialization function called before all other functions to
+ * ensure that these long-lived objects are initialized before being used.
+ *
+ * NVTX C++ makes use of the "construct on first use" technique to alleviate
+ * this inconvenience. In short, a function local static object is constructed
+ * upon the first invocation of a function and returns a reference to that
+ * object on all future invocations. See the documentation for `nvtx3::domain`,
+ * `nvtx3::named_category`, `nvtx3::registered_string`, and
+ * https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use for more
+ * information.
+ *
+ * Using construct on first use, the above example becomes:
+ * \code{.cpp}
+ * struct my_domain{ static constexpr char const* name{"my domain"}; };
+ *
+ * // The first invocation of `domain::get` for the type `my_domain` will
+ * // construct a `nvtx3::domain` object and return a reference to it. Future
+ * // invocations simply return a reference.
+ * nvtx3::domain const& D = nvtx3::domain::get<my_domain>();
+ * \endcode
+ * For more information about NVTX and how it can be used, see
+ * https://docs.nvidia.com/cuda/profiler-users-guide/index.html#nvtx and
+ * https://devblogs.nvidia.com/cuda-pro-tip-generate-custom-application-profile-timelines-nvtx/
+ * for more information.
+ *
+ * \section RANGES Ranges
+ *
+ * Ranges are used to describe a span of time during the execution of an
+ * application. Common examples are using ranges to annotate the time it takes
+ * to execute a function or an iteration of a loop.
+ *
+ * NVTX C++ uses RAII to automate the generation of ranges that are tied to the
+ * lifetime of objects. Similar to `std::lock_guard` in the C++ Standard
+ * Template Library.
+ *
+ * \subsection scoped_range Scoped Range
+ *
+ * `nvtx3::scoped_range_in` is a class that begins a range upon construction
+ * and ends the range at destruction. This is one of the most commonly used
+ * constructs in NVTX C++ and is useful for annotating spans of time on a
+ * particular thread. These ranges can be nested to arbitrary depths.
+ *
+ * `nvtx3::scoped_range` is an alias for a `nvtx3::scoped_range_in` in the
+ * global NVTX domain. For more information about Domains, see \ref DOMAINS.
+ *
+ * Various attributes of a range can be configured constructing a
+ * `nvtx3::scoped_range_in` with a `nvtx3::event_attributes` object. For
+ * more information, see \ref ATTRIBUTES.
+ *
+ * Example:
+ *
+ * \code{.cpp}
+ * void some_function() {
+ *    // Creates a range for the duration of `some_function`
+ *    nvtx3::scoped_range r{};
+ *
+ *    while(true) {
+ *       // Creates a range for every loop iteration
+ *       // `loop_range` is nested inside `r`
+ *       nvtx3::scoped_range loop_range{};
+ *    }
+ * }
+ * \endcode
+ *
+ * \subsection unique_range Unique Range
+ *
+ * `nvtx3::unique_range` is similar to `nvtx3::scoped_range`, with a few key differences:
+ * - `unique_range` objects can be destroyed in any order whereas `scoped_range` objects must be
+ *    destroyed in exact reverse creation order
+ * - `unique_range` can start and end on different threads
+ * - `unique_range` is movable
+ * - `unique_range` objects can be constructed as heap objects
+ *
+ * There is extra overhead associated with `unique_range` constructs and therefore use of
+ * `nvtx3::scoped_range_in` should be preferred.
+ *
+ * \section MARKS Marks
+ *
+ * `nvtx3::mark` annotates an instantaneous point in time with a "marker".
+ *
+ * Unlike a "range" which has a beginning and an end, a marker is a single event
+ * in an application, such as detecting a problem:
+ *
+ * \code{.cpp}
+ * bool success = do_operation(...);
+ * if (!success) {
+ *    nvtx3::mark("operation failed!");
+ * }
+ * \endcode
+ *
+ * \section DOMAINS Domains
+ *
+ * Similar to C++ namespaces, domains allow for scoping NVTX events. By default,
+ * all NVTX events belong to the "global" domain. Libraries and applications
+ * should scope their events to use a custom domain to differentiate where the
+ * events originate from.
+ *
+ * It is common for a library or application to have only a single domain and
+ * for the name of that domain to be known at compile time. Therefore, Domains
+ * in NVTX C++ are represented by _tag types_.
+ *
+ * For example, to define a custom domain, simply define a new concrete type
+ * (a `class` or `struct`) with a `static` member called `name` that contains
+ * the desired name of the domain.
+ *
+ * \code{.cpp}
+ * struct my_domain{ static constexpr char const* name{"my domain"}; };
+ * \endcode
+ *
+ * For any NVTX C++ construct that can be scoped to a domain, the type
+ * `my_domain` can be passed as an explicit template argument to scope it to
+ * the custom domain.
+ *
+ * The tag type `nvtx3::domain::global` represents the global NVTX domain.
+ *
+ * \code{.cpp}
+ * // By default, `scoped_range_in` belongs to the global domain
+ * nvtx3::scoped_range_in<> r0{};
+ *
+ * // Alias for a `scoped_range_in` in the global domain
+ * nvtx3::scoped_range r1{};
+ *
+ * // `r` belongs to the custom domain
+ * nvtx3::scoped_range_in<my_domain> r{};
+ * \endcode
+ *
+ * When using a custom domain, it is recommended to define type aliases for NVTX
+ * constructs in the custom domain.
+ * \code{.cpp}
+ * using my_scoped_range = nvtx3::scoped_range_in<my_domain>;
+ * using my_registered_string = nvtx3::registered_string_in<my_domain>;
+ * using my_named_category = nvtx3::named_category_in<my_domain>;
+ * \endcode
+ *
+ * See `nvtx3::domain` for more information.
+ *
+ * \section ATTRIBUTES Event Attributes
+ *
+ * NVTX events can be customized with various attributes to provide additional
+ * information (such as a custom message) or to control visualization of the
+ * event (such as the color used). These attributes can be specified per-event
+ * via arguments to a `nvtx3::event_attributes` object.
+ *
+ * NVTX events can be customized via five "attributes":
+ * - \ref COLOR : color used to visualize the event in tools.
+ * - \ref MESSAGES :  Custom message string.
+ * - \ref PAYLOAD :  User-defined numerical value.
+ * - \ref PAYLOAD_DATA : User-defined structured data (exclusive of payload).
+ * - \ref CATEGORY : Intra-domain grouping.
+ *
+ * It is possible to construct a `nvtx3::event_attributes` from any number of
+ * attribute objects (nvtx3::color, nvtx3::message, nvtx3::payload,
+ * nvtx3::category, nvtx3::payload_data, or a container of nvtx3::payload_data)
+ * in any order. If an attribute is not specified, a tool specific default value
+ * is used. See `nvtx3::event_attributes` for more information.
+ *
+ * \code{.cpp}
+ * // Set message, same as passing nvtx3::message{"message"}
+ * nvtx3::event_attributes attr{"message"};
+ *
+ * // Set message and color
+ * nvtx3::event_attributes attr{"message", nvtx3::rgb{127, 255, 0}};
+ *
+ * // Set message, color, payload, category
+ * nvtx3::event_attributes attr{"message",
+ *                              nvtx3::rgb{127, 255, 0},
+ *                              nvtx3::payload{42},
+ *                              nvtx3::category{1}};
+ *
+ * // Same as above -- can use any order of arguments
+ * nvtx3::event_attributes attr{nvtx3::payload{42},
+ *                              nvtx3::category{1},
+ *                              "message",
+ *                              nvtx3::rgb{127, 255, 0}};
+ *
+ * // Multiple arguments of the same type are allowed, but only the first is
+ * // used -- in this example, payload is set to 42:
+ * nvtx3::event_attributes attr{ nvtx3::payload{42}, nvtx3::payload{7} };
+ * // payload and payload_data should not be used together.
+ *
+ * // Using the nvtx3 namespace in a local scope makes the syntax more succinct:
+ * using namespace nvtx3;
+ * event_attributes attr{"message", rgb{127, 255, 0}, payload{42}, category{1}};
+ * \endcode
+ *
+ * \subsection MESSAGES message
+ *
+ * `nvtx3::message` sets the message string for an NVTX event.
+ *
+ * Example:
+ * \code{.cpp}
+ * // Create an `event_attributes` with the message "my message"
+ * nvtx3::event_attributes attr{nvtx3::message{"my message"}};
+ *
+ * // strings and string literals implicitly assumed to be a `nvtx3::message`
+ * nvtx3::event_attributes attr{"my message"};
+ * \endcode
+ *
+ * \subsubsection REGISTERED_MESSAGE Registered Messages
+ *
+ * Associating a `nvtx3::message` with an event requires copying the contents of
+ * the message every time the message is used, i.e., copying the entire message
+ * string. This may cause non-trivial overhead in performance sensitive code.
+ *
+ * To eliminate this overhead, NVTX allows registering a message string,
+ * yielding a "handle" that is inexpensive to copy that may be used in place of
+ * a message string. When visualizing the events, tools such as Nsight Systems
+ * will take care of mapping the message handle to its string.
+ *
+ * A message should be registered once and the handle reused throughout the rest
+ * of the application. This can be done by either explicitly creating static
+ * `nvtx3::registered_string` objects, or using the
+ * `nvtx3::registered_string::get` construct on first use helper (recommended).
+ *
+ * Similar to \ref DOMAINS, `nvtx3::registered_string::get` requires defining a
+ * custom tag type with a static `message` member whose value will be the
+ * contents of the registered string.
+ *
+ * Example:
+ * \code{.cpp}
+ * // Explicitly constructed, static `registered_string` in my_domain:
+ * static registered_string_in<my_domain> static_message{"my message"};
+ *
+ * // Or use construct on first use:
+ * // Define a tag type with a `message` member string to register
+ * struct my_message{ static constexpr char const* message{ "my message" }; };
+ *
+ * // Uses construct on first use to register the contents of
+ * // `my_message::message`
+ * auto& msg = nvtx3::registered_string_in<my_domain>::get<my_message>();
+ * \endcode
+ *
+ * A `nvtx3::registered_string_in` can also be used inside of a struct for
+ * `nvtx3::payload_data` using `TYPE_NVTX_REGISTERED_STRING_HANDLE`.
+ *
+ * \code{.cpp}
+ *
+ * \endcode
+ *
+ * \subsection COLOR color
+ *
+ * Associating a `nvtx3::color` with an event allows controlling how the event
+ * is visualized in a tool such as Nsight Systems. This is a convenient way to
+ * visually differentiate among different events.
+ *
+ * \code{.cpp}
+ * // Define a color via rgb color values
+ * nvtx3::color c{nvtx3::rgb{127, 255, 0}};
+ * nvtx3::event_attributes attr{c};
+ *
+ * // rgb color values can be passed directly to an `event_attributes`
+ * nvtx3::event_attributes attr1{nvtx3::rgb{127,255,0}};
+ * \endcode
+ *
+ * \subsection CATEGORY category
+ *
+ * A `nvtx3::category` is simply an integer id that allows for fine-grain
+ * grouping of NVTX events. For example, one might use separate categories for
+ * IO, memory allocation, compute, etc.
+ *
+ * \code{.cpp}
+ * nvtx3::event_attributes{nvtx3::category{1}};
+ * \endcode
+ *
+ * \subsubsection NAMED_CATEGORIES Named Categories
+ *
+ * Associates a `name` string with a category `id` to help differentiate among
+ * categories.
+ *
+ * For any given category id `Id`, a `named_category{Id, "name"}` should only
+ * be constructed once and reused throughout an application. This can be done by
+ * either explicitly creating static `nvtx3::named_category` objects, or using
+ * the `nvtx3::named_category::get` construct on first use helper (recommended).
+ *
+ * Similar to \ref DOMAINS, `nvtx3::named_category::get` requires defining a
+ * custom tag type with static `name` and `id` members.
+ *
+ * \code{.cpp}
+ * // Explicitly constructed, static `named_category` in my_domain:
+ * static nvtx3::named_category_in<my_domain> static_category{42, "my category"};
+ *
+ * // Or use construct on first use:
+ * // Define a tag type with `name` and `id` members
+ * struct my_category {
+ *    static constexpr char const* name{"my category"}; // category name
+ *    static constexpr uint32_t id{42}; // category id
+ * };
+ *
+ * // Use construct on first use to name the category id `42`
+ * // with name "my category":
+ * auto& cat = named_category_in<my_domain>::get<my_category>();
+ *
+ * // Range `r` associated with category id `42`
+ * nvtx3::event_attributes attr{cat};
+ * \endcode
+ *
+ * \subsection PAYLOAD payload
+ *
+ * Allows associating a user-defined numerical value with an event.
+ *
+ * \code{.cpp}
+ * // Constructs a payload from the `int32_t` value 42
+ * nvtx3:: event_attributes attr{nvtx3::payload{42}};
+ * \endcode
+ *
+ * \subsection PAYLOAD_DATA payload_data
+ *
+ * `nvtx3::payload_data` allows associating arbitrary structured data with an NVTX event.
+ *
+ * First, define a `struct` that is *standard-layout* and *trivially copyable*.
+ * Then use `NVTX3_DEFINE_SCHEMA_GET` (`NVTX3_V1_DEFINE_SCHEMA_GET()`) to define the schema layout.
+ * Finally you can use any such instance wrapped in `nvtx3::payload_data` in an
+ * `nvtx3::event_attributes` object.
+ * You can also pass containers (e.g., `std::vector`, `std::array`) of `payload_data` objects.
+ * \note Constructing `nvtx3::payload_data` from temporaries or using tempoarary
+ * `nvtx3::payload_data` objects is disabled to prevent dangling pointers.
+ *
+ * \section EXAMPLE Example
+ *
+ * Putting it all together:
+ * \code{.cpp}
+ * // Define a custom domain tag type
+ * struct my_domain{ static constexpr char const* name{"my domain"}; };
+ *
+ * // Define a named category tag type
+ * struct my_category{
+ *    static constexpr char const* name{"my category"};
+ *    static constexpr uint32_t id{42};
+ * };
+ *
+ * // Define a registered string tag type
+ * struct my_message{ static constexpr char const* message{"my message"}; };
+ *
+ * // For convenience, use aliases for domain scoped objects
+ * using my_scoped_range = nvtx3::scoped_range_in<my_domain>;
+ * using my_registered_string = nvtx3::registered_string_in<my_domain>;
+ * using my_named_category = nvtx3::named_category_in<my_domain>;
+ *
+ * // Custom payload data
+ * struct my_payload_data {
+ *     uint32_t iteration;
+ *     float    temperature;
+ * };
+ * NVTX3_DEFINE_SCHEMA_GET(
+ *     my_domain,
+ *     my_payload_data,
+ *     "MyPayloadData",
+ *     NVTX_PAYLOAD_ENTRIES((iteration, TYPE_UINT32, "Iteration Count"),
+ *                          (temperature, TYPE_FLOAT, "Temperature"))
+ * )
+ *
+ * // Default values for all attributes
+ * nvtx3::event_attributes attr{};
+ * my_scoped_range r0{attr};
+ *
+ * // Custom (unregistered) message, and unnamed category
+ * nvtx3::event_attributes attr1{"message", nvtx3::category{2}};
+ * my_scoped_range r1{attr1};
+ *
+ * // Alternatively, pass arguments of `event_attributes` constructor directly
+ * // to `my_scoped_range`
+ * my_scoped_range r2{"message", nvtx3::category{2}};
+ *
+ * // construct on first use a registered string
+ * auto& msg = my_registered_string::get<my_message>();
+ *
+ * // construct on first use a named category
+ * auto& cat = my_named_category::get<my_category>();
+ *
+ * // Use registered string and named category with a custom payload
+ * my_scoped_range r3{msg, cat, nvtx3::payload{42}};
+ *
+ * // Use custom payload data
+ * my_payload_data extras{42, 0.7f};
+ * nvtx3::payload_data pd{extras};
+ * my_scoped_range r4{pd};
+ *
+ * // Use a container of payload_data, can use different struct types
+ * auto multiple = std::to_array({pd, pd2});
+ * my_scoped_range r5{multiple};
+ *
+ * // Any number of arguments in any order
+ * my_scoped_range r{nvtx3::rgb{127, 255, 0}, msg};
+ *
+ * \endcode
+ * \section MACROS Convenience Macros
+ *
+ * Oftentimes users want to quickly and easily add NVTX ranges to their library
+ * or application to aid in profiling and optimization.
+ *
+ * A convenient way to do this is to use the \ref NVTX3_FUNC_RANGE and
+ * \ref NVTX3_FUNC_RANGE_IN macros. These macros take care of constructing an
+ * `nvtx3::scoped_range_in` with the name of the enclosing function as the
+ * range's message.
+ *
+ * \code{.cpp}
+ * void some_function() {
+ *    // Automatically generates an NVTX range for the duration of the function
+ *    // using "some_function" as the event's message.
+ *    NVTX3_FUNC_RANGE();
+ * }
+ * \endcode
+ *
+ */
+
+/* Temporary helper #defines, removed with #undef at end of header */
+
+/* Some compilers do not correctly support SFINAE, which is used in this API
+ * to detect common usage errors and provide clearer error messages (by using
+ * static_assert) than the compiler would produce otherwise.  These compilers
+ * will generate errors while compiling this file such as:
+ *
+ *  error: 'name' is not a member of 'nvtx3::v1::domain::global'
+ *
+ * The following compiler versions are known to have this problem, and so are
+ * set by default to disable the SFINAE-based checks:
+ *
+ * - All MSVC versions prior to VS2017 Update 7 (15.7)
+ * - GCC 8.1-8.3 (the problem was fixed in GCC 8.4)
+ *
+ * If you find your compiler hits this problem, you can work around it by
+ * defining NVTX3_USE_CHECKED_OVERLOADS_FOR_GET to 0 before including this
+ * header, or you can add a check for your compiler version to this #if.
+ * Also, please report the issue on the NVTX GitHub page.
+ */
+#if !defined(NVTX3_USE_CHECKED_OVERLOADS_FOR_GET)
+#if defined(_MSC_VER) && _MSC_VER < 1914 \
+  || defined(__GNUC__) && __GNUC__ == 8 && __GNUC_MINOR__ < 4
+#define NVTX3_USE_CHECKED_OVERLOADS_FOR_GET 0
+#else
+#define NVTX3_USE_CHECKED_OVERLOADS_FOR_GET 1
+#endif
+#define NVTX3_USE_CHECKED_OVERLOADS_FOR_GET_DEFINED_HERE
+#endif
+
+/* Within this header, nvtx3::NVTX3_VERSION_NAMESPACE resolves to nvtx3::vX,
+ * where "X" is the major version number. */
+#define NVTX3_CONCAT(A, B) A##B
+#define NVTX3_NAMESPACE_FOR(VERSION) NVTX3_CONCAT(v, VERSION)
+#define NVTX3_VERSION_NAMESPACE NVTX3_NAMESPACE_FOR(NVTX3_CPP_VERSION_MAJOR)
+/* We use a different prefix to avoid ambiguity with the version namespace */
+#define NVTX3_MINOR_NAMESPACE_FOR(VERSION) NVTX3_CONCAT(mv, VERSION)
+#define NVTX3_MINOR_VERSION_NAMESPACE NVTX3_MINOR_NAMESPACE_FOR(NVTX3_CPP_VERSION_MINOR)
+
+/* Avoid duplicating #if defined(NVTX3_INLINE_THIS_VERSION) for namespaces
+ * in each minor version by making a macro to use unconditionally, which
+ * resolves to "inline" or nothing as appropriate. */
+#if defined(NVTX3_INLINE_THIS_VERSION)
+#define NVTX3_INLINE_IF_REQUESTED inline
+#else
+#define NVTX3_INLINE_IF_REQUESTED
+#endif
+
+/* Enables the use of constexpr when support for C++14 constexpr is present.
+ *
+ * Initialization of a class member that is a union to a specific union member
+ * can only be done in the body of a constructor, not in a member initializer
+ * list.  A constexpr constructor must have an empty body until C++14, so there
+ * is no way to make an initializer of a member union constexpr in C++11.  This
+ * macro allows making functions constexpr in C++14 or newer, but non-constexpr
+ * in C++11 compilation.  It is used here on constructors that initialize their
+ * member unions.
+ */
+#if __cpp_constexpr >= 201304L
+#define NVTX3_CONSTEXPR_IF_CPP14 constexpr
+#else
+#define NVTX3_CONSTEXPR_IF_CPP14
+#endif
+
+/* Enables the use of constexpr when support for C++20 constexpr is present.
+ */
+#if __cplusplus >= 202002L
+#define NVTX3_CONSTEXPR_IF_CPP20 constexpr
+#else
+#define NVTX3_CONSTEXPR_IF_CPP20
+#endif
+
+// Macro wrappers for C++ attributes
+#if !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(x) 0
+#endif
+#if __has_cpp_attribute(maybe_unused)
+#define NVTX3_MAYBE_UNUSED [[maybe_unused]]
+#else
+#define NVTX3_MAYBE_UNUSED
+#endif
+#if __has_cpp_attribute(nodiscard)
+#define NVTX3_NO_DISCARD [[nodiscard]]
+#else
+#define NVTX3_NO_DISCARD
+#endif
+
+ /* Use a macro for static asserts, which defaults to static_assert, but that
+  * testing tools can replace with a logging function.  For example:
+  * #define NVTX3_STATIC_ASSERT(c, m) \
+  *   do { if (!(c)) printf("static_assert would fail: %s\n", m); } while (0)
+  */
+#if !defined(NVTX3_STATIC_ASSERT)
+#define NVTX3_STATIC_ASSERT(condition, message) static_assert(condition, message)
+#define NVTX3_STATIC_ASSERT_DEFINED_HERE
+#endif
+
+/* Implementation sections, enclosed in guard macros for each minor version */
+
+#ifndef NVTX3_CPP_DEFINITIONS_V1_0
+#define NVTX3_CPP_DEFINITIONS_V1_0
+
+#include "nvToolsExt.h"
+#include "nvToolsExtPayload.h"
+#include "nvToolsExtPayloadHelper.h"
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <cstddef>
+#include <cstdint>
+
+namespace nvtx3 {
+
+NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE
+{
+inline namespace NVTX3_MINOR_VERSION_NAMESPACE
+{
+
+namespace detail {
+
+template <typename Unused>
+struct always_false : std::false_type {};
+
+template <typename T, typename = void>
+struct has_name : std::false_type {};
+template <typename T>
+struct has_name<T, decltype((void)T::name, void())> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_id : std::false_type {};
+template <typename T>
+struct has_id<T, decltype((void)T::id, void())> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_message : std::false_type {};
+template <typename T>
+struct has_message<T, decltype((void)T::message, void())> : std::true_type {};
+
+template <typename T, typename = void>
+struct is_c_string : std::false_type {};
+template <typename T>
+struct is_c_string<T, typename std::enable_if<
+  std::is_convertible<T, char const*   >::value ||
+  std::is_convertible<T, wchar_t const*>::value
+>::type> : std::true_type {};
+
+template <typename T>
+using is_uint32 = std::is_same<typename std::decay<T>::type, uint32_t>;
+
+template <typename... Args>
+static inline void silence_unused(Args const&...) noexcept {}
+
+// Type trait to check for a .data() member returning T* or const T*
+// Some day, we can just use std::span
+template <typename T, typename TD>
+struct has_data_member
+{
+private:
+    template <typename U>
+    static auto test_data(int) -> decltype(std::declval<const U>().data());
+    template <typename>
+    static auto test_data(...) -> void;
+    using return_type = decltype(test_data<T>(0));
+
+public:
+    static constexpr bool value =
+        std::is_same<return_type, TD*>::value || std::is_same<return_type, TD const*>::value;
+};
+
+// Type trait to check for a .size() member returning something convertible to size_t
+template <typename T>
+struct has_size_member
+{
+private:
+    template <typename U>
+    static auto test_size(int) -> decltype(std::declval<const U>().size());
+    template <typename>
+    static auto test_size(...) -> void;
+    using return_type = decltype(test_size<T>(0));
+
+public:
+    static constexpr bool value = !std::is_same<return_type, void>::value &&
+                                    std::is_convertible<return_type, size_t>::value;
+};
+
+/**
+    * To ensure that we can "safely" use one type as another, for pointers, in
+    * arrays or in structs. This is used for our wrappers around C-types so that
+    * we can pass them back to C.
+    *
+    * This is by no means perfect and foolproof.
+    *
+    * @tparam W The wrapper type.
+    * @tparam U The type it is wrapping.
+    */
+template <typename W, typename U, typename = void>
+struct is_safe_wrapper_of : std::false_type
+{
+};
+
+template <typename W, typename U>
+struct is_safe_wrapper_of<
+    W,
+    U,
+    typename std::enable_if<
+        std::is_standard_layout<W>::value && std::is_standard_layout<U>::value &&
+        std::is_trivially_copyable<W>::value && std::is_trivially_copyable<U>::value &&
+        sizeof(W) == sizeof(U)>::type> : std::true_type
+{
+};
+} // namespace detail
+
+/**
+ * @brief `domain`s allow for grouping NVTX events into a single scope to
+ * differentiate them from events in other `domain`s.
+ *
+ * By default, all NVTX constructs are placed in the "global" NVTX domain.
+ *
+ * A custom `domain` may be used in order to differentiate a library's or
+ * application's NVTX events from other events.
+ *
+ * `domain`s are expected to be long-lived and unique to a library or
+ * application. As such, it is assumed a domain's name is known at compile
+ * time. Therefore, all NVTX constructs that can be associated with a domain
+ * require the domain to be specified via a *type* `D` passed as an
+ * explicit template parameter.
+ *
+ * The type `domain::global` may be used to indicate that the global NVTX
+ * domain should be used.
+ *
+ * None of the C++ NVTX constructs require the user to manually construct a
+ * `domain` object. Instead, if a custom domain is desired, the user is
+ * expected to define a type `D` that contains a member
+ * `D::name` which resolves to either a `char const*` or `wchar_t
+ * const*`. The value of `D::name` is used to name and uniquely
+ * identify the custom domain.
+ *
+ * Upon the first use of an NVTX construct associated with the type
+ * `D`, the "construct on first use" pattern is used to construct a
+ * function local static `domain` object. All future NVTX constructs
+ * associated with `D` will use a reference to the previously
+ * constructed `domain` object. See `domain::get`.
+ *
+ * Example:
+ * \code{.cpp}
+ * // The type `my_domain` defines a `name` member used to name and identify
+ * // the `domain` object identified by `my_domain`.
+ * struct my_domain{ static constexpr char const* name{"my_domain"}; };
+ *
+ * // The NVTX range `r` will be grouped with all other NVTX constructs
+ * // associated with  `my_domain`.
+ * nvtx3::scoped_range_in<my_domain> r{};
+ *
+ * // An alias can be created for a `scoped_range_in` in the custom domain
+ * using my_scoped_range = nvtx3::scoped_range_in<my_domain>;
+ * my_scoped_range my_range{};
+ *
+ * // `domain::global` indicates that the global NVTX domain is used
+ * nvtx3::scoped_range_in<domain::global> r2{};
+ *
+ * // For convenience, `nvtx3::scoped_range` is an alias for a range in the
+ * // global domain
+ * nvtx3::scoped_range r3{};
+ * \endcode
+ */
+class domain {
+ public:
+  domain(domain const&) = delete;
+  domain& operator=(domain const&) = delete;
+  domain(domain&&) = delete;
+  domain& operator=(domain&&) = delete;
+
+  /**
+   * @brief Tag type for the "global" NVTX domain.
+   *
+   * This type may be passed as a template argument to any function/class
+   * expecting a type to identify a domain to indicate that the global domain
+   * should be used.
+   *
+   * All NVTX events in the global domain across all libraries and
+   * applications will be grouped together.
+   *
+   */
+  struct global {
+  };
+
+#if NVTX3_USE_CHECKED_OVERLOADS_FOR_GET
+  /**
+   * @brief Returns reference to an instance of a function local static
+   * `domain` object.
+   *
+   * Uses the "construct on first use" idiom to safely ensure the `domain`
+   * object is initialized exactly once upon first invocation of
+   * `domain::get<D>()`. All following invocations will return a
+   * reference to the previously constructed `domain` object. See
+   * https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
+   *
+   * None of the constructs in this header require the user to directly invoke
+   * `domain::get`. It is automatically invoked when constructing objects like
+   * a `scoped_range_in` or `category`. Advanced users may wish to use
+   * `domain::get` for the convenience of the "construct on first use" idiom
+   * when using domains with their own use of the NVTX C API.
+   *
+   * This function is thread-safe as of C++11. If two or more threads call
+   * `domain::get<D>` concurrently, exactly one of them is guaranteed
+   * to construct the `domain` object and the other(s) will receive a
+   * reference to the object after it is fully constructed.
+   *
+   * The domain's name is specified via the type `D` pass as an
+   * explicit template parameter. `D` is required to contain a
+   * member `D::name` that resolves to either a `char const*` or
+   * `wchar_t const*`. The value of `D::name` is used to name and
+   * uniquely identify the `domain`.
+   *
+   * Example:
+   * \code{.cpp}
+   * // The type `my_domain` defines a `name` member used to name and identify
+   * // the `domain` object identified by `my_domain`.
+   * struct my_domain{ static constexpr char const* name{"my domain"}; };
+   *
+   * auto& D1 = domain::get<my_domain>(); // First invocation constructs a
+   *                                      // `domain` with the name "my domain"
+   *
+   * auto& D2 = domain::get<my_domain>(); // Quickly returns reference to
+   *                                      // previously constructed `domain`.
+   * \endcode
+   *
+   * @tparam D Type that contains a `D::name` member used to
+   * name the `domain` object.
+   * @return Reference to the `domain` corresponding to the type `D`.
+   */
+  template <typename D = global,
+    typename std::enable_if<
+      detail::is_c_string<decltype(D::name)>::value
+    , int>::type = 0>
+  NVTX3_NO_DISCARD static domain const& get() noexcept
+  {
+    static domain const d(D::name);
+    return d;
+  }
+
+  /**
+   * @brief Overload of `domain::get` to provide a clear compile error when
+   * `D` has a `name` member that is not directly convertible to either
+   * `char const*` or `wchar_t const*`.
+   */
+  template <typename D = global,
+    typename std::enable_if<
+      !detail::is_c_string<decltype(D::name)>::value
+    , int>::type = 0>
+  NVTX3_NO_DISCARD static domain const& get() noexcept
+  {
+    NVTX3_STATIC_ASSERT(detail::always_false<D>::value,
+      "Type used to identify an NVTX domain must contain a static constexpr member "
+      "called 'name' of type const char* or const wchar_t* -- 'name' member is not "
+      "convertible to either of those types");
+    static domain const unused;
+    return unused;  // Function must compile for static_assert to be triggered
+  }
+
+  /**
+   * @brief Overload of `domain::get` to provide a clear compile error when
+   * `D` does not have a `name` member.
+   */
+  template <typename D = global,
+    typename std::enable_if<
+      !detail::has_name<D>::value
+    , int>::type = 0>
+  NVTX3_NO_DISCARD static domain const& get() noexcept
+  {
+    NVTX3_STATIC_ASSERT(detail::always_false<D>::value,
+      "Type used to identify an NVTX domain must contain a static constexpr member "
+      "called 'name' of type const char* or const wchar_t* -- 'name' member is missing");
+    static domain const unused;
+    return unused;  // Function must compile for static_assert to be triggered
+  }
+#else
+  template <typename D = global>
+  NVTX3_NO_DISCARD static domain const& get() noexcept
+  {
+    static domain const d(D::name);
+    return d;
+  }
+#endif
+
+  /**
+   * @brief Conversion operator to `nvtxDomainHandle_t`.
+   *
+   * Allows transparently passing a domain object into an API expecting a
+   * native `nvtxDomainHandle_t` object.
+   */
+  operator nvtxDomainHandle_t() const noexcept { return _domain; }
+
+ private:
+  /**
+   * @brief Construct a new domain with the specified `name`.
+   *
+   * This constructor is private as it is intended that `domain` objects only
+   * be created through the `domain::get` function.
+   *
+   * @param name A unique name identifying the domain
+   */
+  explicit domain(char const* name) noexcept : _domain{nvtxDomainCreateA(name)} {}
+
+  /**
+   * @brief Construct a new domain with the specified `name`.
+   *
+   * This constructor is private as it is intended that `domain` objects only
+   * be created through the `domain::get` function.
+   *
+   * @param name A unique name identifying the domain
+   */
+  explicit domain(wchar_t const* name) noexcept : _domain{nvtxDomainCreateW(name)} {}
+
+  /**
+   * @brief Construct a new domain with the specified `name`.
+   *
+   * This constructor is private as it is intended that `domain` objects only
+   * be created through the `domain::get` function.
+   *
+   * @param name A unique name identifying the domain
+   */
+  explicit domain(std::string const& name) noexcept : domain{name.c_str()} {}
+
+  /**
+   * @brief Construct a new domain with the specified `name`.
+   *
+   * This constructor is private as it is intended that `domain` objects only
+   * be created through the `domain::get` function.
+   *
+   * @param name A unique name identifying the domain
+   */
+  explicit domain(std::wstring const& name) noexcept : domain{name.c_str()} {}
+
+  /**
+   * @brief Default constructor creates a `domain` representing the
+   * "global" NVTX domain.
+   *
+   * All events not associated with a custom `domain` are grouped in the
+   * "global" NVTX domain.
+   *
+   */
+  constexpr domain() noexcept {}
+
+  /**
+   * @brief Intentionally avoid calling nvtxDomainDestroy on the `domain` object.
+   *
+   * No currently-available tools attempt to free domain resources when the
+   * nvtxDomainDestroy function is called, due to the thread-safety and
+   * efficiency challenges of freeing thread-local storage for other threads.
+   * Since libraries may be disallowed from introducing static destructors,
+   * and destroying the domain is likely to have no effect, the destructor
+   * for `domain` intentionally chooses to not destroy the domain.
+   *
+   * In a situation where domain destruction is necessary, either manually
+   * call nvtxDomainDestroy on the domain's handle, or make a class that
+   * derives from `domain` and calls nvtxDomainDestroy in its destructor.
+   */
+  ~domain() = default;
+
+ private:
+  nvtxDomainHandle_t const _domain{};  ///< The `domain`s NVTX handle
+};
+
+/**
+ * @brief Returns reference to the `domain` object that represents the global
+ * NVTX domain.
+ *
+ * This specialization for `domain::global` returns a default constructed,
+ * `domain` object for use when the "global" domain is desired.
+ *
+ * All NVTX events in the global domain across all libraries and applications
+ * will be grouped together.
+ *
+ * @return Reference to the `domain` corresponding to the global NVTX domain.
+ *
+ */
+template <>
+NVTX3_NO_DISCARD inline domain const& domain::get<domain::global>() noexcept
+{
+  static domain const d{};
+  return d;
+}
+
+/**
+ * @brief Indicates the values of the red, green, and blue color channels for
+ * an RGB color to use as an event attribute (assumes no transparency).
+ *
+ */
+struct rgb {
+  /// Type used for component values
+  using component_type = uint8_t;
+
+  /**
+   * @brief Construct a rgb with red, green, and blue channels
+   * specified by `red_`, `green_`, and `blue_`, respectively.
+   *
+   * Valid values are in the range `[0,255]`.
+   *
+   * @param red_ Value of the red channel
+   * @param green_ Value of the green channel
+   * @param blue_ Value of the blue channel
+   */
+  constexpr rgb(
+    component_type red_,
+    component_type green_,
+    component_type blue_) noexcept
+    : red{red_}, green{green_}, blue{blue_}
+  {
+  }
+
+  component_type red{};    ///< Red channel value
+  component_type green{};  ///< Green channel value
+  component_type blue{};   ///< Blue channel value
+};
+
+/**
+ * @brief Indicates the value of the alpha, red, green, and blue color
+ * channels for an ARGB color to use as an event attribute.
+ *
+ */
+struct argb final : rgb {
+  /**
+   * @brief Construct an argb with alpha, red, green, and blue channels
+   * specified by `alpha_`, `red_`, `green_`, and `blue_`, respectively.
+   *
+   * Valid values are in the range `[0,255]`.
+   *
+   * @param alpha_  Value of the alpha channel (opacity)
+   * @param red_  Value of the red channel
+   * @param green_  Value of the green channel
+   * @param blue_  Value of the blue channel
+   *
+   */
+  constexpr argb(
+    component_type alpha_,
+    component_type red_,
+    component_type green_,
+    component_type blue_) noexcept
+    : rgb{red_, green_, blue_}, alpha{alpha_}
+  {
+  }
+
+  component_type alpha{};  ///< Alpha channel value
+};
+
+/**
+ * @brief Represents a custom color that can be associated with an NVTX event
+ * via its `event_attributes`.
+ *
+ * Specifying colors for NVTX events is a convenient way to visually
+ * differentiate among different events in a visualization tool such as Nsight
+ * Systems.
+ *
+ */
+class color {
+ public:
+  /// Type used for the color's value
+  using value_type = uint32_t;
+
+  /**
+   * @brief Constructs a `color` using the value provided by `hex_code`.
+   *
+   * `hex_code` is expected to be a 4 byte argb hex code.
+   *
+   * The most significant byte indicates the value of the alpha channel
+   * (opacity) (0-255)
+   *
+   * The next byte indicates the value of the red channel (0-255)
+   *
+   * The next byte indicates the value of the green channel (0-255)
+   *
+   * The least significant byte indicates the value of the blue channel
+   * (0-255)
+   *
+   * @param hex_code The hex code used to construct the `color`
+   */
+  constexpr explicit color(value_type hex_code) noexcept : _value{hex_code} {}
+
+  /**
+   * @brief Construct a `color` using the alpha, red, green, blue components
+   * in `argb`.
+   *
+   * @param argb_ The alpha, red, green, blue components of the desired `color`
+   */
+  constexpr color(argb argb_) noexcept
+    : color{from_bytes_msb_to_lsb(argb_.alpha, argb_.red, argb_.green, argb_.blue)}
+  {
+  }
+
+  /**
+   * @brief Construct a `color` using the red, green, blue components in
+   * `rgb`.
+   *
+   * Uses maximum value for the alpha channel (opacity) of the `color`.
+   *
+   * @param rgb_ The red, green, blue components of the desired `color`
+   */
+  constexpr color(rgb rgb_) noexcept
+    : color{from_bytes_msb_to_lsb(0xFF, rgb_.red, rgb_.green, rgb_.blue)}
+  {
+  }
+
+  /**
+   * @brief Returns the `color`s argb hex code
+   *
+   */
+  constexpr value_type get_value() const noexcept { return _value; }
+
+  /**
+   * @brief Return the NVTX color type of the color.
+   *
+   */
+  constexpr nvtxColorType_t get_type() const noexcept { return _type; }
+
+  color() = delete;
+  ~color() = default;
+  color(color const&) = default;
+  color& operator=(color const&) = default;
+  color(color&&) = default;
+  color& operator=(color&&) = default;
+
+ private:
+  /**
+   * @brief Constructs an unsigned, 4B integer from the component bytes in
+   * most to least significant byte order.
+   *
+   */
+  constexpr static value_type from_bytes_msb_to_lsb(
+    uint8_t byte3,
+    uint8_t byte2,
+    uint8_t byte1,
+    uint8_t byte0) noexcept
+  {
+    return uint32_t{byte3} << 24 | uint32_t{byte2} << 16 | uint32_t{byte1} << 8 | uint32_t{byte0};
+  }
+
+  value_type _value{};                     ///< color's argb color code
+  nvtxColorType_t _type{NVTX_COLOR_ARGB};  ///< NVTX color type code
+};
+
+/**
+ * @brief Object for intra-domain grouping of NVTX events.
+ *
+ * A `category` is simply an integer id that allows for fine-grain grouping of
+ * NVTX events. For example, one might use separate categories for IO, memory
+ * allocation, compute, etc.
+ *
+ * Example:
+ * \code{.cpp}
+ * nvtx3::category cat1{1};
+ *
+ * // Range `r1` belongs to the category identified by the value `1`.
+ * nvtx3::scoped_range r1{cat1};
+ *
+ * // Range `r2` belongs to the same category as `r1`
+ * nvtx3::scoped_range r2{nvtx3::category{1}};
+ * \endcode
+ *
+ * To associate a name string with a category id, see `named_category`.
+ *
+ */
+class category {
+ public:
+  /// Type used for `category`s integer id.
+  using id_type = uint32_t;
+
+  /**
+   * @brief Construct a `category` with the specified `id`.
+   *
+   * The `category` will be unnamed and identified only by its `id` value.
+   *
+   * All `category`s in a domain sharing the same `id` are equivalent.
+   *
+   * @param[in] id The `category`'s identifying value
+   */
+  constexpr explicit category(id_type id) noexcept : id_{id} {}
+
+  /**
+   * @brief Returns the id of the category.
+   *
+   */
+  constexpr id_type get_id() const noexcept { return id_; }
+
+  category() = delete;
+  ~category() = default;
+  category(category const&) = default;
+  category& operator=(category const&) = default;
+  category(category&&) = default;
+  category& operator=(category&&) = default;
+
+ private:
+  id_type id_{};  ///< category's unique identifier
+};
+
+/**
+ * @brief A `category` with an associated name string.
+ *
+ * Associates a `name` string with a category `id` to help differentiate among
+ * categories.
+ *
+ * For any given category id `Id`, a `named_category(Id, "name")` should only
+ * be constructed once and reused throughout an application. This can be done
+ * by either explicitly creating static `named_category` objects, or using the
+ * `named_category::get` construct on first use helper (recommended).
+ *
+ * Creating two or more `named_category` objects with the same value for `id`
+ * in the same domain results in undefined behavior.
+ *
+ * Similarly, behavior is undefined when a `named_category` and `category`
+ * share the same value of `id`.
+ *
+ * Example:
+ * \code{.cpp}
+ * // Explicitly constructed, static `named_category` in global domain:
+ * static nvtx3::named_category static_category{42, "my category"};
+ *
+ * // Range `r` associated with category id `42`
+ * nvtx3::scoped_range r{static_category};
+ *
+ * // OR use construct on first use:
+ *
+ * // Define a type with `name` and `id` members
+ * struct my_category {
+ *    static constexpr char const* name{"my category"}; // category name
+ *    static constexpr uint32_t id{42}; // category id
+ * };
+ *
+ * // Use construct on first use to name the category id `42`
+ * // with name "my category"
+ * auto& cat = named_category_in<my_domain>::get<my_category>();
+ *
+ * // Range `r` associated with category id `42`
+ * nvtx3::scoped_range r{cat};
+ * \endcode
+ *
+ * `named_category_in<D>`'s association of a name to a category id is local to
+ * the domain specified by the type `D`. An id may have a different name in
+ * another domain.
+ *
+ * @tparam D Type containing `name` member used to identify the `domain` to
+ * which the `named_category_in` belongs. Else, `domain::global` to indicate
+ * that the global NVTX domain should be used.
+ */
+template <typename D = domain::global>
+class named_category_in final : public category {
+ public:
+#if NVTX3_USE_CHECKED_OVERLOADS_FOR_GET
+  /**
+   * @brief Returns a global instance of a `named_category_in` as a
+   * function-local static.
+   *
+   * Creates a `named_category_in<D>` with name and id specified by the contents
+   * of a type `C`. `C::name` determines the name and `C::id` determines the
+   * category id.
+   *
+   * This function is useful for constructing a named `category` exactly once
+   * and reusing the same instance throughout an application.
+   *
+   * Example:
+   * \code{.cpp}
+   * // Define a type with `name` and `id` members
+   * struct my_category {
+   *    static constexpr char const* name{"my category"}; // category name
+   *    static constexpr uint32_t id{42}; // category id
+   * };
+   *
+   * // Use construct on first use to name the category id `42`
+   * // with name "my category"
+   * auto& cat = named_category_in<my_domain>::get<my_category>();
+   *
+   * // Range `r` associated with category id `42`
+   * nvtx3::scoped_range r{cat};
+   * \endcode
+   *
+   * Uses the "construct on first use" idiom to safely ensure the `category`
+   * object is initialized exactly once. See
+   * https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
+   *
+   * @tparam C Type containing a member `C::name` that resolves to either a
+   * `char const*` or `wchar_t const*` and `C::id`.
+   */
+  template <typename C,
+    typename std::enable_if<
+      detail::is_c_string<decltype(C::name)>::value &&
+      detail::is_uint32<decltype(C::id)>::value
+    , int>::type = 0>
+  static named_category_in const& get() noexcept
+  {
+    static named_category_in const cat(C::id, C::name);
+    return cat;
+  }
+
+  /**
+   * @brief Overload of `named_category_in::get` to provide a clear compile error
+   * when `C` has the required `name` and `id` members, but they are not the
+   * required types.  `name` must be directly convertible to `char const*` or
+   * `wchar_t const*`, and `id` must be `uint32_t`.
+   */
+  template <typename C,
+    typename std::enable_if<
+      !detail::is_c_string<decltype(C::name)>::value ||
+      !detail::is_uint32<decltype(C::id)>::value
+    , int>::type = 0>
+  NVTX3_NO_DISCARD static named_category_in const& get() noexcept
+  {
+    NVTX3_STATIC_ASSERT(detail::is_c_string<decltype(C::name)>::value,
+      "Type used to name an NVTX category must contain a static constexpr member "
+      "called 'name' of type const char* or const wchar_t* -- 'name' member is not "
+      "convertible to either of those types");
+    NVTX3_STATIC_ASSERT(detail::is_uint32<decltype(C::id)>::value,
+      "Type used to name an NVTX category must contain a static constexpr member "
+      "called 'id' of type uint32_t -- 'id' member is the wrong type");
+    static named_category_in const unused;
+    return unused;  // Function must compile for static_assert to be triggered
+  }
+
+  /**
+   * @brief Overload of `named_category_in::get` to provide a clear compile error
+   * when `C` does not have the required `name` and `id` members.
+   */
+  template <typename C,
+    typename std::enable_if<
+      !detail::has_name<C>::value ||
+      !detail::has_id<C>::value
+    , int>::type = 0>
+  NVTX3_NO_DISCARD static named_category_in const& get() noexcept
+  {
+    NVTX3_STATIC_ASSERT(detail::has_name<C>::value,
+      "Type used to name an NVTX category must contain a static constexpr member "
+      "called 'name' of type const char* or const wchar_t* -- 'name' member is missing");
+    NVTX3_STATIC_ASSERT(detail::has_id<C>::value,
+      "Type used to name an NVTX category must contain a static constexpr member "
+      "called 'id' of type uint32_t -- 'id' member is missing");
+    static named_category_in const unused;
+    return unused;  // Function must compile for static_assert to be triggered
+  }
+#else
+  template <typename C>
+  NVTX3_NO_DISCARD static named_category_in const& get() noexcept
+  {
+    static named_category_in const cat(C::id, C::name);
+    return cat;
+  }
+#endif
+
+ private:
+  // Default constructor is only used internally for static_assert(false) cases.
+  named_category_in() noexcept : category{0} {}
+
+ public:
+  /**
+   * @brief Construct a `named_category_in` with the specified `id` and `name`.
+   *
+   * The name `name` will be registered with `id`.
+   *
+   * Every unique value of `id` should only be named once.
+   *
+   * @param[in] id The category id to name
+   * @param[in] name The name to associated with `id`
+   */
+  named_category_in(id_type id, char const* name) noexcept : category{id}
+  {
+#ifndef NVTX_DISABLE
+    nvtxDomainNameCategoryA(domain::get<D>(), get_id(), name);
+#else
+    (void)id;
+    (void)name;
+#endif
+  }
+
+  /**
+   * @brief Construct a `named_category_in` with the specified `id` and `name`.
+   *
+   * The name `name` will be registered with `id`.
+   *
+   * Every unique value of `id` should only be named once.
+   *
+   * @param[in] id The category id to name
+   * @param[in] name The name to associated with `id`
+   */
+  named_category_in(id_type id, wchar_t const* name) noexcept : category{id}
+  {
+#ifndef NVTX_DISABLE
+    nvtxDomainNameCategoryW(domain::get<D>(), get_id(), name);
+#else
+    (void)id;
+    (void)name;
+#endif
+  }
+};
+
+/**
+ * @brief Alias for a `named_category_in` in the global NVTX domain.
+ *
+ */
+using named_category = named_category_in<domain::global>;
+
+/**
+ * @brief A message registered with NVTX.
+ *
+ * Normally, associating a `message` with an NVTX event requires copying the
+ * contents of the message string. This may cause non-trivial overhead in
+ * highly performance sensitive regions of code.
+ *
+ * message registration is an optimization to lower the overhead of
+ * associating a message with an NVTX event. Registering a message yields a
+ * handle that is inexpensive to copy that may be used in place of a message
+ * string.
+ *
+ * A particular message should only be registered once and the handle
+ * reused throughout the rest of the application. This can be done by either
+ * explicitly creating static `registered_string_in` objects, or using the
+ * `registered_string_in::get` construct on first use helper (recommended).
+ *
+ * Example:
+ * \code{.cpp}
+ * // Explicitly constructed, static `registered_string` in my_domain:
+ * static registered_string_in<my_domain> static_message{"message"};
+ *
+ * // "message" is associated with the range `r`
+ * nvtx3::scoped_range r{static_message};
+ *
+ * // Or use construct on first use:
+ *
+ * // Define a type with a `message` member that defines the contents of the
+ * // registered string
+ * struct my_message{ static constexpr char const* message{ "my message" }; };
+ *
+ * // Uses construct on first use to register the contents of
+ * // `my_message::message`
+ * auto& msg = registered_string_in<my_domain>::get<my_message>();
+ *
+ * // "my message" is associated with the range `r`
+ * nvtx3::scoped_range r{msg};
+ * \endcode
+ *
+ * `registered_string_in`s are local to a particular domain specified via
+ * the type `D`.
+ *
+ * @tparam D Type containing `name` member used to identify the `domain` to
+ * which the `registered_string_in` belongs. Else, `domain::global` to indicate
+ * that the global NVTX domain should be used.
+ */
+template <typename D = domain::global>
+class registered_string_in {
+ public:
+#if NVTX3_USE_CHECKED_OVERLOADS_FOR_GET
+  /**
+   * @brief Returns a global instance of a `registered_string_in` as a function
+   * local static.
+   *
+   * Provides a convenient way to register a message with NVTX without having
+   * to explicitly register the message.
+   *
+   * Upon first invocation, constructs a `registered_string_in` whose contents
+   * are specified by `message::message`.
+   *
+   * All future invocations will return a reference to the object constructed
+   * in the first invocation.
+   *
+   * Example:
+   * \code{.cpp}
+   * // Define a type with a `message` member that defines the contents of the
+   * // registered string
+   * struct my_message{ static constexpr char const* message{ "my message" };
+   * };
+   *
+   * // Uses construct on first use to register the contents of
+   * // `my_message::message`
+   * auto& msg = registered_string_in<my_domain>::get<my_message>();
+   *
+   * // "my message" is associated with the range `r`
+   * nvtx3::scoped_range r{msg};
+   * \endcode
+   *
+   * @tparam M Type required to contain a member `M::message` that
+   * resolves to either a `char const*` or `wchar_t const*` used as the
+   * registered string's contents.
+   * @return Reference to a `registered_string_in` associated with the type `M`.
+   */
+  template <typename M,
+    typename std::enable_if<
+      detail::is_c_string<decltype(M::message)>::value
+    , int>::type = 0>
+  NVTX3_NO_DISCARD static registered_string_in const& get() noexcept
+  {
+    static registered_string_in const regstr(M::message);
+    return regstr;
+  }
+
+  /**
+   * @brief Overload of `registered_string_in::get` to provide a clear compile error
+   * when `M` has a `message` member that is not directly convertible to either
+   * `char const*` or `wchar_t const*`.
+   */
+  template <typename M,
+    typename std::enable_if<
+      !detail::is_c_string<decltype(M::message)>::value
+    , int>::type = 0>
+  NVTX3_NO_DISCARD static registered_string_in const& get() noexcept
+  {
+    NVTX3_STATIC_ASSERT(detail::always_false<M>::value,
+      "Type used to register an NVTX string must contain a static constexpr member "
+      "called 'message' of type const char* or const wchar_t* -- 'message' member is "
+      "not convertible to either of those types");
+    static registered_string_in const unused;
+    return unused;  // Function must compile for static_assert to be triggered
+  }
+
+  /**
+   * @brief Overload of `registered_string_in::get` to provide a clear compile error when
+   * `M` does not have a `message` member.
+   */
+  template <typename M,
+    typename std::enable_if<
+      !detail::has_message<M>::value
+    , int>::type = 0>
+  NVTX3_NO_DISCARD static registered_string_in const& get() noexcept
+  {
+    NVTX3_STATIC_ASSERT(detail::always_false<M>::value,
+      "Type used to register an NVTX string must contain a static constexpr member "
+      "called 'message' of type const char* or const wchar_t* -- 'message' member "
+      "is missing");
+    static registered_string_in const unused;
+    return unused;  // Function must compile for static_assert to be triggered
+  }
+#else
+  template <typename M>
+  NVTX3_NO_DISCARD static registered_string_in const& get() noexcept
+  {
+    static registered_string_in const regstr(M::message);
+    return regstr;
+  }
+#endif
+
+  /**
+   * @brief Constructs a `registered_string_in` from the specified `msg` string.
+   *
+   * Registers `msg` with NVTX and associates a handle with the registered
+   * message.
+   *
+   * A particular message should should only be registered once and the handle
+   * reused throughout the rest of the application.
+   *
+   * @param msg The contents of the message
+   */
+  explicit registered_string_in(char const* msg) noexcept
+    : handle_{nvtxDomainRegisterStringA(domain::get<D>(), msg)}
+  {
+  }
+
+  /**
+   * @brief Constructs a `registered_string_in` from the specified `msg` string.
+   *
+   * Registers `msg` with NVTX and associates a handle with the registered
+   * message.
+   *
+   * A particular message should should only be registered once and the handle
+   * reused throughout the rest of the application.
+   *
+   * @param msg The contents of the message
+   */
+  explicit registered_string_in(std::string const& msg) noexcept
+    : registered_string_in{msg.c_str()} {}
+
+  /**
+   * @brief Constructs a `registered_string_in` from the specified `msg` string.
+   *
+   * Registers `msg` with NVTX and associates a handle with the registered
+   * message.
+   *
+   * A particular message should should only be registered once and the handle
+   * reused throughout the rest of the application.
+   *
+   * @param msg The contents of the message
+   */
+  explicit registered_string_in(wchar_t const* msg) noexcept
+    : handle_{nvtxDomainRegisterStringW(domain::get<D>(), msg)}
+  {
+  }
+
+  /**
+   * @brief Constructs a `registered_string_in` from the specified `msg` string.
+   *
+   * Registers `msg` with NVTX and associates a handle with the registered
+   * message.
+   *
+   * A particular message should should only be registered once and the handle
+   * reused throughout the rest of the application.
+   *
+   * @param msg The contents of the message
+   */
+  explicit registered_string_in(std::wstring const& msg) noexcept
+    : registered_string_in{msg.c_str()} {}
+
+  /**
+   * @brief Returns the registered string's handle
+   *
+   */
+  nvtxStringHandle_t get_handle() const noexcept
+  {
+    // We want to ensure that we can use the registered_string in place of a handle
+    // in a payload data struct.
+    NVTX3_STATIC_ASSERT(
+      (detail::is_safe_wrapper_of<registered_string_in<D>, nvtxStringHandle_t>::value),
+      "Internal error! registered_string_in is potentially unsafe.");
+    return handle_;
+  }
+
+private:
+  // Default constructor is only used internally for static_assert(false) cases.
+  registered_string_in() noexcept {}
+public:
+  ~registered_string_in() = default;
+  registered_string_in(registered_string_in const&) = default;
+  registered_string_in& operator=(registered_string_in const&) = default;
+  registered_string_in(registered_string_in&&) = default;
+  registered_string_in& operator=(registered_string_in&&) = default;
+
+ private:
+  nvtxStringHandle_t handle_{};  ///< The handle returned from
+                                 ///< registering the message with NVTX
+};
+
+/**
+ * @brief Alias for a `registered_string_in` in the global NVTX domain.
+ *
+ */
+using registered_string = registered_string_in<domain::global>;
+
+/**
+ * @brief Allows associating a message string with an NVTX event via
+ * its `EventAttribute`s.
+ *
+ * Associating a `message` with an NVTX event through its `event_attributes`
+ * allows for naming events to easily differentiate them from other events.
+ *
+ * Every time an NVTX event is created with an associated `message`, the
+ * contents of the message string must be copied.  This may cause non-trivial
+ * overhead in highly performance sensitive sections of code. Use of a
+ * `nvtx3::registered_string` is recommended in these situations.
+ *
+ * Example:
+ * \code{.cpp}
+ * // Creates an `event_attributes` with message "message 0"
+ * nvtx3::event_attributes attr0{nvtx3::message{"message 0"}};
+ *
+ * // `range0` contains message "message 0"
+ * nvtx3::scoped_range range0{attr0};
+ *
+ * // `std::string` and string literals are implicitly assumed to be
+ * // the contents of an `nvtx3::message`
+ * // Creates an `event_attributes` with message "message 1"
+ * nvtx3::event_attributes attr1{"message 1"};
+ *
+ * // `range1` contains message "message 1"
+ * nvtx3::scoped_range range1{attr1};
+ *
+ * // `range2` contains message "message 2"
+ * nvtx3::scoped_range range2{nvtx3::message{"message 2"}};
+ *
+ * // `std::string` and string literals are implicitly assumed to be
+ * // the contents of an `nvtx3::message`
+ * // `range3` contains message "message 3"
+ * nvtx3::scoped_range range3{"message 3"};
+ * \endcode
+ */
+class message {
+ public:
+  using value_type = nvtxMessageValue_t;
+
+  /**
+   * @brief Construct a `message` whose contents are specified by `msg`.
+   *
+   * @param msg The contents of the message
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 message(char const* msg) noexcept : type_{NVTX_MESSAGE_TYPE_ASCII}
+  {
+    value_.ascii = msg;
+  }
+
+  /**
+   * @brief Construct a `message` whose contents are specified by `msg`.
+   *
+   * @param msg The contents of the message
+   */
+  message(std::string const& msg) noexcept : message{msg.c_str()} {}
+
+  /**
+   * @brief Disallow construction for `std::string` r-value
+   *
+   * `message` is a non-owning type and therefore cannot take ownership of an
+   * r-value. Therefore, constructing from an r-value is disallowed to prevent
+   * a dangling pointer.
+   *
+   */
+#ifndef NVTX3_ALLOW_RVALUE_CONSTRUCTORS
+  message(std::string&&) = delete;
+#endif
+
+  /**
+   * @brief Construct a `message` whose contents are specified by `msg`.
+   *
+   * @param msg The contents of the message
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 message(wchar_t const* msg) noexcept : type_{NVTX_MESSAGE_TYPE_UNICODE}
+  {
+    value_.unicode = msg;
+  }
+
+  /**
+   * @brief Construct a `message` whose contents are specified by `msg`.
+   *
+   * @param msg The contents of the message
+   */
+  message(std::wstring const& msg) noexcept : message{msg.c_str()} {}
+
+  /**
+   * @brief Disallow construction for `std::wstring` r-value
+   *
+   * `message` is a non-owning type and therefore cannot take ownership of an
+   * r-value. Therefore, constructing from an r-value is disallowed to prevent
+   * a dangling pointer.
+   *
+   */
+#ifndef NVTX3_ALLOW_RVALUE_CONSTRUCTORS
+  message(std::wstring&&) = delete;
+#endif
+
+  /**
+   * @brief Construct a `message` from a `registered_string_in`.
+   *
+   * @tparam D Type containing `name` member used to identify the `domain`
+   * to which the `registered_string_in` belongs. Else, `domain::global` to
+   * indicate that the global NVTX domain should be used.
+   * @param msg The message that has already been registered with NVTX.
+   */
+  template <typename D>
+  NVTX3_CONSTEXPR_IF_CPP14 message(registered_string_in<D> const& msg) noexcept
+    : type_{NVTX_MESSAGE_TYPE_REGISTERED}
+  {
+    value_.registered = msg.get_handle();
+  }
+
+  /**
+   * @brief Construct a `message` from NVTX C API type and value.
+   *
+   * @param type nvtxMessageType_t enum value indicating type of the payload
+   * @param value nvtxMessageValue_t union containing message
+   */
+  constexpr message(
+    nvtxMessageType_t const& type,
+    nvtxMessageValue_t const& value) noexcept
+    : type_{type}, value_(value)
+  {
+  }
+
+  /**
+   * @brief Construct a `message` from NVTX C API registered string handle.
+   *
+   * @param handle nvtxStringHandle_t value of registered string handle
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 message(nvtxStringHandle_t handle) noexcept
+    : type_{NVTX_MESSAGE_TYPE_REGISTERED}
+  {
+    value_.registered = handle;
+  }
+
+  /**
+   * @brief Return the union holding the value of the message.
+   *
+   */
+  constexpr value_type get_value() const noexcept { return value_; }
+
+  /**
+   * @brief Return the type information about the value the union holds.
+   *
+   */
+  constexpr nvtxMessageType_t get_type() const noexcept { return type_; }
+
+ private:
+  nvtxMessageType_t type_{};    ///< message type
+  nvtxMessageValue_t value_{};  ///< message contents
+};
+
+/**
+ * @brief A numerical value that can be associated with an NVTX event via
+ * its `event_attributes`.
+ *
+ * Example:
+ * \code{.cpp}
+ * // Constructs a payload from the int32_t value 42
+ * nvtx3:: event_attributes attr{nvtx3::payload{42}};
+ *
+ * // `range0` will have an int32_t payload of 42
+ * nvtx3::scoped_range range0{attr};
+ *
+ * // range1 has double payload of 3.14
+ * nvtx3::scoped_range range1{nvtx3::payload{3.14}};
+ * \endcode
+ */
+class payload {
+ public:
+  using value_type = typename nvtxEventAttributes_v2::payload_t;
+
+  /**
+   * @brief Construct a `payload` from a signed, 8 byte integer.
+   *
+   * @param value Value to use as contents of the payload
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 explicit payload(int64_t value) noexcept
+    : type_{NVTX_PAYLOAD_TYPE_INT64}, value_{}
+  {
+    value_.llValue = value;
+  }
+
+  /**
+   * @brief Construct a `payload` from a signed, 4 byte integer.
+   *
+   * @param value Value to use as contents of the payload
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 explicit payload(int32_t value) noexcept
+    : type_{NVTX_PAYLOAD_TYPE_INT32}, value_{}
+  {
+    value_.iValue = value;
+  }
+
+  /**
+   * @brief Construct a `payload` from an unsigned, 8 byte integer.
+   *
+   * @param value Value to use as contents of the payload
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 explicit payload(uint64_t value) noexcept
+    : type_{NVTX_PAYLOAD_TYPE_UNSIGNED_INT64}, value_{}
+  {
+    value_.ullValue = value;
+  }
+
+  /**
+   * @brief Construct a `payload` from an unsigned, 4 byte integer.
+   *
+   * @param value Value to use as contents of the payload
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 explicit payload(uint32_t value) noexcept
+    : type_{NVTX_PAYLOAD_TYPE_UNSIGNED_INT32}, value_{}
+  {
+    value_.uiValue = value;
+  }
+
+  /**
+   * @brief Construct a `payload` from a single-precision floating point
+   * value.
+   *
+   * @param value Value to use as contents of the payload
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 explicit payload(float value) noexcept
+    : type_{NVTX_PAYLOAD_TYPE_FLOAT}, value_{}
+  {
+    value_.fValue = value;
+  }
+
+  /**
+   * @brief Construct a `payload` from a double-precision floating point
+   * value.
+   *
+   * @param value Value to use as contents of the payload
+   */
+  NVTX3_CONSTEXPR_IF_CPP14 explicit payload(double value) noexcept
+    : type_{NVTX_PAYLOAD_TYPE_DOUBLE}, value_{}
+  {
+    value_.dValue = value;
+  }
+
+  /**
+   * @brief Construct a `payload` from NVTX C API type and value.
+   *
+   * @param type nvtxPayloadType_t enum value indicating type of the payload
+   * @param value nvtxEventAttributes_t::payload_t union containing payload
+   */
+  constexpr payload(
+    nvtxPayloadType_t const& type,
+    value_type const& value) noexcept
+    : type_{type}, value_(value)
+  {
+  }
+
+  /**
+   * @brief Return the union holding the value of the payload
+   *
+   */
+  constexpr value_type get_value() const noexcept { return value_; }
+
+  /**
+   * @brief Return the information about the type the union holds.
+   *
+   */
+  constexpr nvtxPayloadType_t get_type() const noexcept { return type_; }
+
+ private:
+  nvtxPayloadType_t type_;  ///< Type of the payload value
+  value_type value_;        ///< Union holding the payload value
+};
+
+/**
+ * @brief Represents the registered schema for a payload struct.
+ *
+ * This class encapsulates the schema ID obtained by registering a payload struct
+ * using `nvtxPayloadSchemaRegister`. The primary mechanism for obtaining an
+ * instance is via the static template function `get<T>()`, which must be
+ * specialized for each payload struct type `T` using the
+ * `NVTX3_DEFINE_SCHEMA_GET` (`NVTX3_V1_DEFINE_SCHEMA_GET()`) macro.
+ *
+ * The schema ID is used internally when constructing `payload_data` objects.
+ */
+class schema
+{
+private:
+  /**
+   * @brief Private default constructor.
+   *
+   * Used only internally for static_assert(false) cases.
+   */
+  schema()
+      : _schema_id{0}
+  {}
+
+  public:
+  schema(schema const&) = delete;
+  schema& operator=(schema const&) = delete;
+  schema(schema&&) = delete;
+  schema& operator=(schema&&) = delete;
+
+  /**
+   * @brief Constructs a schema object directly from a schema ID.
+   *
+   * This constructor is primarily for internal use or advanced scenarios where
+   * the schema ID is obtained manually.
+   *
+   * @param id The NVTX schema ID.
+   */
+  explicit schema(uint64_t id)
+      : _schema_id{id}
+  {}
+
+  /**
+   * @brief Gets the schema instance for a specific payload struct type.
+   *
+   * This function relies on template specialization. Users must provide a
+   * specialization for each payload struct type `T` using the
+   * `NVTX3_DEFINE_SCHEMA_GET` (`NVTX3_V1_DEFINE_SCHEMA_GET()`) macro.
+   *
+   * @tparam T The payload struct type for which to get the schema.
+   * @return A constant reference to the schema object for type `T`.
+   */
+  template <typename T>
+  NVTX3_NO_DISCARD static schema const& get() noexcept
+  {
+    NVTX3_STATIC_ASSERT(
+        detail::always_false<T>::value,
+        "payload_data schema deduction requires a template specialization. Use the macro "
+        "NVTX3_DEFINE_SCHEMA_GET to generate this specialization.");
+    static schema unused;
+    return unused;
+  }
+
+  /**
+   * @brief Return the underlying C handle of the schema.
+   */
+  uint64_t get_handle() const noexcept
+  {
+    return _schema_id;
+  }
+
+private:
+  uint64_t const _schema_id;
+};
+
+/**
+ * @brief Wrapper around the NVTX C API `nvtxPayloadData_t` struct.
+ *
+ * This class facilitates associating a structured payload with an NVTX event.
+ * It combines a pointer to the payload data instance with its registered schema
+ * ID and size.
+ */
+class payload_data
+{
+public:
+  /**
+   * @brief Constructs `payload_data` from an existing NVTX C API struct.
+   *
+   * Provides interoperability with code using the NVTX C API directly.
+   *
+   * @param pd An existing `nvtxPayloadData_t` struct.
+   */
+  explicit payload_data(nvtxPayloadData_t const& pd)
+      : data_(pd)
+  {}
+
+  /**
+   * @brief Constructs `payload_data` for a specific payload struct instance.
+   *
+   * This template constructor automatically retrieves the necessary information
+   * from the given struct type `T` and the reference to the instance.
+   * The type `T` must be standard layout and trivially copyable as well as
+   * have a `schema::get<T>()` specialization via `NVTX3_DEFINE_SCHEMA_GET` (`NVTX3_V1_DEFINE_SCHEMA_GET()`).
+   *
+   * Make sure the provided referenace is valid for the lifetime of the created
+   * `payload_data` object.
+   *
+   * @param t A constant reference to the payload struct instance.
+   */
+  // We cannot simply delete the rvalue constructor here because with a template
+  // parameter that would be a forwarding reference. Thus, we have this one
+  // ctor with a forwarding reference and use a static assert for the rvalue check.
+  // Disable this for the C-style nvtxPayloadData_t to prefer above ctor for non-const.
+  template <
+      typename R,
+      typename T = typename std::remove_cv<typename std::remove_reference<R>::type>::type,
+      typename = typename std::enable_if<!std::is_same<T, nvtxPayloadData_t>::value>::type>
+  explicit payload_data(R&& t)
+      : data_{schema::get<T>().get_handle(), sizeof(T), &t}
+  {
+#ifndef NVTX3_ALLOW_RVALUE_CONSTRUCTORS
+    NVTX3_STATIC_ASSERT(
+        std::is_lvalue_reference<R>::value,
+        "payload_data requires an lvalue reference to the underlying data. Constructing "
+        "from an rvalue is potentially unsafe and therefore forbidden.");
+#endif
+    NVTX3_STATIC_ASSERT(
+        std::is_standard_layout<T>::value && std::is_trivially_copyable<T>::value,
+        "structs used for NVTX3 payload schema must be standard layout and trivially copyable");
+  }
+
+  /**
+   * @brief Constructs `payload_data` for a payload instance with a given schema.
+   *
+   * Use this constructor if you have a dynamic schema for your struct rather than
+   * a static one defined by `NVTX3_DEFINE_SCHEMA_GET` (`NVTX3_V1_DEFINE_SCHEMA_GET()`).
+   *
+   * Make sure the provided referenace is valid for the lifetime of the created
+   * `payload_data` object.
+   *
+   * @param t A constant reference to the payload struct instance.
+   * @param s The schema to use for the payload data.
+   */
+  template <typename T>
+  explicit payload_data(T const& t, schema s)
+      : data_{s.get_handle(), sizeof(T), &t}
+  {
+    NVTX3_STATIC_ASSERT(
+        std::is_standard_layout<T>::value && std::is_trivially_copyable<T>::value,
+        "structs used for NVTX3 payload schema must be standard layout and trivially copyable");
+  }
+
+  /**
+   * @return A pointer to the `nvtxPayloadData_t` struct as ullValue to use
+   * with NVTX C API functions.
+   */
+  uint64_t as_ull_value() const noexcept
+  {
+    NVTX3_STATIC_ASSERT(
+        (detail::is_safe_wrapper_of<payload_data, nvtxPayloadData_t>::value),
+        "Internal error! payload_data is potentially unsafe.");
+    return NVTX_POINTER_AS_PAYLOAD_ULLVALUE(&data_);
+  }
+
+private:
+  nvtxPayloadData_t data_;
+};
+
+/**
+ * @brief Describes the attributes of a NVTX event.
+ *
+ * NVTX events can be customized via four "attributes":
+ *
+ * - color:    color used to visualize the event in tools such as Nsight
+ *             Systems. See `color`.
+ * - message:  Custom message string. See `message`.
+ * - payload:  User-defined numerical value. See `payload`.
+ * - category: Intra-domain grouping. See `category`.
+ *
+ * These component attributes are specified via an `event_attributes` object.
+ * See `nvtx3::color`, `nvtx3::message`, `nvtx3::payload`, and
+ * `nvtx3::category` for how these individual attributes are constructed.
+ *
+ * While it is possible to specify all four attributes, it is common to want
+ * to only specify a subset of attributes and use default values for the
+ * others. For convenience, `event_attributes` can be constructed from any
+ * number of attribute components in any order.
+ *
+ * Example:
+ * \code{.cpp}
+ * // Set message, same as using nvtx3::message{"message"}
+ * event_attributes attr{"message"};
+ *
+ * // Set message and color
+ * event_attributes attr{"message", nvtx3::rgb{127, 255, 0}};
+ *
+ * // Set message, color, payload, category
+ * event_attributes attr{"message",
+ *                       nvtx3::rgb{127, 255, 0},
+ *                       nvtx3::payload{42},
+ *                       nvtx3::category{1}};
+ *
+ * // Same as above -- can use any order of arguments
+ * event_attributes attr{nvtx3::payload{42},
+ *                       nvtx3::category{1},
+ *                       "message",
+ *                       nvtx3::rgb{127, 255, 0}};
+ *
+ * // Multiple arguments of the same type are allowed, but only the first is
+ * // used -- in this example, payload is set to 42:
+ * event_attributes attr{ nvtx3::payload{42}, nvtx3::payload{7} };
+ *
+ * // Range `r` will be customized according the attributes in `attr`
+ * nvtx3::scoped_range r{attr};
+ *
+ * // For convenience, `event_attributes` constructor arguments may be passed
+ * // to the `scoped_range_in` constructor -- they are forwarded to the
+ * // `event_attributes` constructor
+ * nvtx3::scoped_range r{nvtx3::payload{42}, nvtx3::category{1}, "message"};
+ *
+ * // Using the nvtx3 namespace in a local scope makes the syntax more succinct:
+ * using namespace nvtx3;
+ * scoped_range r{payload{42}, category{1}, "message"};
+ *
+ * \endcode
+ *
+ */
+class event_attributes {
+ public:
+  using value_type = nvtxEventAttributes_t;
+
+  /**
+   * @brief Default constructor creates an `event_attributes` with no
+   * category, color, payload, nor message.
+   */
+  constexpr event_attributes() noexcept
+    : attributes_{
+        NVTX_VERSION,                   // version
+        sizeof(nvtxEventAttributes_t),  // size
+        0,                              // category
+        NVTX_COLOR_UNKNOWN,             // color type
+        0,                              // color value
+        NVTX_PAYLOAD_UNKNOWN,           // payload type
+        0,                              // reserved 4B
+        {0},                            // payload value (union)
+        NVTX_MESSAGE_UNKNOWN,           // message type
+        {nullptr}                       // message value (union)
+      }
+  {
+  }
+
+  /**
+   * @brief Variadic constructor where the first argument is a `category`.
+   *
+   * Sets the value of the `EventAttribute`s category based on `c` and
+   * forwards the remaining variadic parameter pack to the next constructor.
+   *
+   */
+  template <typename... Args>
+  NVTX3_CONSTEXPR_IF_CPP14 explicit event_attributes(category const& c, Args const&... args) noexcept
+    : event_attributes(args...)
+  {
+    attributes_.category = c.get_id();
+  }
+
+  /**
+   * @brief Variadic constructor where the first argument is a `color`.
+   *
+   * Sets the value of the `EventAttribute`s color based on `c` and forwards
+   * the remaining variadic parameter pack to the next constructor.
+   *
+   */
+  template <typename... Args>
+  NVTX3_CONSTEXPR_IF_CPP14 explicit event_attributes(color const& c, Args const&... args) noexcept
+    : event_attributes(args...)
+  {
+    attributes_.color     = c.get_value();
+    attributes_.colorType = c.get_type();
+  }
+
+  /**
+   * @brief Variadic constructor where the first argument is a `payload`.
+   *
+   * Sets the value of the `EventAttribute`s payload based on `p` and forwards
+   * the remaining variadic parameter pack to the next constructor.
+   *
+   */
+  template <typename... Args>
+  NVTX3_CONSTEXPR_IF_CPP14 explicit event_attributes(payload const& p, Args const&... args) noexcept
+    : event_attributes(args...)
+  {
+    attributes_.payload     = p.get_value();
+    attributes_.payloadType = p.get_type();
+  }
+
+  /**
+   * @brief Variadic constructor where the first argument is a single `payload_data`.
+   *
+   * Sets the value of the `EventAttribute`s payload data based on `pd` and forwards
+   * the remaining variadic parameter pack to the next constructor.
+   *
+   */
+  template <typename... Args>
+  NVTX3_CONSTEXPR_IF_CPP14 explicit event_attributes(payload_data const& pd, Args const&... args) noexcept
+      : event_attributes(args...)
+  {
+    attributes_.payloadType = NVTX_PAYLOAD_TYPE_EXT;
+    attributes_.reserved0 = 1;
+    attributes_.payload.ullValue = pd.as_ull_value();
+  }
+
+  /**
+   * @brief Deleted constructor for `payload_data` rvalue references.
+   *
+   * `event_attributes` is non-owning and therefore cannot take ownership of an r-value
+   * `payload_data`. Therefore this constructor is deleted by default to prevent dangling
+   * pointers.
+   */
+#ifndef NVTX3_ALLOW_RVALUE_CONSTRUCTORS
+  template <typename... Args>
+  NVTX3_CONSTEXPR_IF_CPP14 explicit event_attributes(payload_data&& pd, Args const&... args) = delete;
+#endif
+
+  /**
+   * @brief Variadic constructor template for containers of `payload_data`.
+   *
+   * Associates multiple structured payloads contained in `pdc` with the event attributes.
+   * This constructor is enabled for types that have both a `data()` member function
+   * returning `payload_data*` or `const payload_data*` and a `size()` member function.
+   * E.g., `std::vector` or `std::array` can be used.
+   * Forwards the remaining variadic parameter pack to the next constructor.
+   */
+  template <
+      typename T,
+      typename... Args,
+      typename = typename std::enable_if<
+          detail::has_data_member<T, payload_data>::value && detail::has_size_member<T>::value>::type>
+  NVTX3_CONSTEXPR_IF_CPP20 explicit event_attributes(T&& pdc, Args const&... args) noexcept
+      : event_attributes(args...)
+  {
+    NVTX3_STATIC_ASSERT(
+        std::is_lvalue_reference<T>::value,
+        "event_attributes requires an lvalue reference to the underlying data. "
+        "Constructing from an rvalue is potentially unsafe and therefore forbidden.");
+    attributes_.payloadType = NVTX_PAYLOAD_TYPE_EXT;
+    attributes_.reserved0 = static_cast<int32_t>(pdc.size()); // Cast size to int32_t
+    attributes_.payload.ullValue = pdc.data()->as_ull_value();
+  }
+
+  /**
+   * @brief Variadic constructor where the first argument is a `message`.
+   *
+   * Sets the value of the `EventAttribute`s message based on `m` and forwards
+   * the remaining variadic parameter pack to the next constructor.
+   *
+   */
+  template <typename... Args>
+  NVTX3_CONSTEXPR_IF_CPP14 explicit event_attributes(message const& m, Args const&... args) noexcept
+    : event_attributes(args...)
+  {
+    attributes_.message     = m.get_value();
+    attributes_.messageType = m.get_type();
+  }
+
+  ~event_attributes() = default;
+  event_attributes(event_attributes const&) = default;
+  event_attributes& operator=(event_attributes const&) = default;
+  event_attributes(event_attributes&&) = default;
+  event_attributes& operator=(event_attributes&&) = default;
+
+  /**
+   * @brief Get raw pointer to underlying NVTX attributes object.
+   *
+   */
+  constexpr value_type const* get() const noexcept { return &attributes_; }
+
+ private:
+  value_type attributes_{};  ///< The NVTX attributes structure
+};
+
+/**
+ * @brief A RAII object for creating a NVTX range local to a thread within a
+ * domain.
+ *
+ * When constructed, begins a nested NVTX range on the calling thread in the
+ * specified domain. Upon destruction, ends the NVTX range.
+ *
+ * Behavior is undefined if a `scoped_range_in` object is
+ * created/destroyed on different threads.
+ *
+ * `scoped_range_in` is neither movable nor copyable.
+ *
+ * `scoped_range_in`s may be nested within other ranges.
+ *
+ * The domain of the range is specified by the template type parameter `D`.
+ * By default, the `domain::global` is used, which scopes the range to the
+ * global NVTX domain. The convenience alias `scoped_range` is provided for
+ * ranges scoped to the global domain.
+ *
+ * A custom domain can be defined by creating a type, `D`, with a static
+ * member `D::name` whose value is used to name the domain associated with
+ * `D`. `D::name` must resolve to either `char const*` or `wchar_t const*`
+ *
+ * Example:
+ * \code{.cpp}
+ * // Define a type `my_domain` with a member `name` used to name the domain
+ * // associated with the type `my_domain`.
+ * struct my_domain{
+ *    static constexpr char const* name{"my domain"};
+ * };
+ * \endcode
+ *
+ * Usage:
+ * \code{.cpp}
+ * nvtx3::scoped_range_in<my_domain> r1{"range 1"}; // Range in my domain
+ *
+ * // Three equivalent ways to make a range in the global domain:
+ * nvtx3::scoped_range_in<nvtx3::domain::global> r2{"range 2"};
+ * nvtx3::scoped_range_in<> r3{"range 3"};
+ * nvtx3::scoped_range r4{"range 4"};
+ *
+ * // Create an alias to succinctly make ranges in my domain:
+ * using my_scoped_range = nvtx3::scoped_range_in<my_domain>;
+ *
+ * my_scoped_range r3{"range 3"};
+ * \endcode
+ */
+template <class D = domain::global>
+class NVTX3_MAYBE_UNUSED scoped_range_in {
+ public:
+  /**
+   * @brief Construct a `scoped_range_in` with the specified
+   * `event_attributes`
+   *
+   * Example:
+   * \code{cpp}
+   * nvtx3::event_attributes attr{"msg", nvtx3::rgb{127,255,0}};
+   * nvtx3::scoped_range range{attr}; // Creates a range with message contents
+   *                                  // "msg" and green color
+   * \endcode
+   *
+   * @param[in] attr `event_attributes` that describes the desired attributes
+   * of the range.
+   */
+  explicit scoped_range_in(event_attributes const& attr) noexcept
+  {
+#ifndef NVTX_DISABLE
+    nvtxDomainRangePushEx(domain::get<D>(), attr.get());
+#else
+    (void)attr;
+#endif
+  }
+
+  /**
+   * @brief Constructs a `scoped_range_in` from the constructor arguments
+   * of an `event_attributes`.
+   *
+   * Forwards the arguments `args...` to construct an
+   * `event_attributes` object. The `event_attributes` object is then
+   * associated with the `scoped_range_in`.
+   *
+   * For more detail, see `event_attributes` documentation.
+   *
+   * Example:
+   * \code{cpp}
+   * // Creates a range with message "message" and green color
+   * nvtx3::scoped_range r{"message", nvtx3::rgb{127,255,0}};
+   * \endcode
+   *
+   * @param[in] args Arguments to used to construct an `event_attributes` associated with this
+   * range.
+   *
+   */
+  template <typename... Args>
+  explicit scoped_range_in(Args const&... args) noexcept
+    : scoped_range_in{event_attributes{args...}}
+  {
+  }
+
+  /**
+   * @brief Default constructor creates a `scoped_range_in` with no
+   * message, color, payload, nor category.
+   *
+   */
+  scoped_range_in() noexcept : scoped_range_in{event_attributes{}} {}
+
+  /**
+   * @brief Delete `operator new` to disallow heap allocated objects.
+   *
+   * `scoped_range_in` must follow RAII semantics to guarantee proper push/pop semantics.
+   *
+   */
+  void* operator new(std::size_t) = delete;
+
+  scoped_range_in(scoped_range_in const&) = delete;
+  scoped_range_in& operator=(scoped_range_in const&) = delete;
+  scoped_range_in(scoped_range_in&&) = delete;
+  scoped_range_in& operator=(scoped_range_in&&) = delete;
+
+  /**
+   * @brief Destroy the scoped_range_in, ending the NVTX range event.
+   */
+  ~scoped_range_in() noexcept
+  {
+#ifndef NVTX_DISABLE
+    nvtxDomainRangePop(domain::get<D>());
+#endif
+  }
+};
+
+/**
+ * @brief Alias for a `scoped_range_in` in the global NVTX domain.
+ *
+ */
+using scoped_range = scoped_range_in<domain::global>;
+
+namespace detail {
+
+/// @cond internal
+template <typename D = domain::global>
+class NVTX3_MAYBE_UNUSED optional_scoped_range_in
+{
+public:
+  optional_scoped_range_in() = default;
+
+  void begin(event_attributes const& attr) noexcept
+  {
+#ifndef NVTX_DISABLE
+    // This class is not meant to be part of the public NVTX C++ API and should
+    // only be used in the `NVTX3_FUNC_RANGE_IF` and `NVTX3_FUNC_RANGE_IF_IN`
+    // macros. However, to prevent developers from misusing this class, make
+    // sure to not start multiple ranges.
+    if (initialized) { return; }
+
+    nvtxDomainRangePushEx(domain::get<D>(), attr.get());
+    initialized = true;
+#else
+    (void)attr;
+#endif
+  }
+
+  ~optional_scoped_range_in() noexcept
+  {
+#ifndef NVTX_DISABLE
+    if (initialized) { nvtxDomainRangePop(domain::get<D>()); }
+#endif
+  }
+
+  void* operator new(std::size_t) = delete;
+  optional_scoped_range_in(optional_scoped_range_in const&) = delete;
+  optional_scoped_range_in& operator=(optional_scoped_range_in const&) = delete;
+  optional_scoped_range_in(optional_scoped_range_in&&) = delete;
+  optional_scoped_range_in& operator=(optional_scoped_range_in&&) = delete;
+
+private:
+#ifndef NVTX_DISABLE
+  bool initialized = false;
+#endif
+};
+/// @endcond
+
+} // namespace detail
+
+/**
+ * @brief Handle used for correlating explicit range start and end events.
+ *
+ * A handle is "null" if it does not correspond to any range.
+ *
+ */
+struct range_handle {
+  /// Type used for the handle's value
+  using value_type = nvtxRangeId_t;
+
+
+  /**
+   * @brief Construct a `range_handle` from the given id.
+   *
+   */
+  constexpr explicit range_handle(value_type id) noexcept : _range_id{id} {}
+
+  /**
+   * @brief Constructs a null range handle.
+   *
+   * A null range_handle corresponds to no range. Calling `end_range` on a
+   * null handle is undefined behavior when a tool is active.
+   *
+   */
+  constexpr range_handle() noexcept = default;
+
+  /**
+   * @brief Checks whether this handle is null
+   *
+   * Provides contextual conversion to `bool`.
+   *
+   * \code{cpp}
+   * range_handle handle{};
+   * if (handle) {...}
+   * \endcode
+   *
+   */
+  constexpr explicit operator bool() const noexcept { return get_value() != null_range_id; }
+
+  /**
+   * @brief Implicit conversion from `nullptr` constructs a null handle.
+   *
+   * Satisfies the "NullablePointer" requirement to make `range_handle` comparable with `nullptr`.
+   *
+   */
+  constexpr range_handle(std::nullptr_t) noexcept {}
+
+  /**
+   * @brief Returns the `range_handle`'s value
+   *
+   * @return value_type The handle's value
+   */
+  constexpr value_type get_value() const noexcept { return _range_id; }
+
+ private:
+  /// Sentinel value for a null handle that corresponds to no range
+  static constexpr value_type null_range_id = nvtxRangeId_t{0};
+
+  value_type _range_id{null_range_id};  ///< The underlying NVTX range id
+};
+
+/**
+ * @brief Compares two range_handles for equality
+ *
+ * @param lhs The first range_handle to compare
+ * @param rhs The second range_handle to compare
+ */
+inline constexpr bool operator==(range_handle lhs, range_handle rhs) noexcept
+{
+  return lhs.get_value() == rhs.get_value();
+}
+
+/**
+ * @brief Compares two range_handles for inequality
+ *
+ * @param lhs The first range_handle to compare
+ * @param rhs The second range_handle to compare
+ */
+inline constexpr bool operator!=(range_handle lhs, range_handle rhs) noexcept { return !(lhs == rhs); }
+
+/**
+ * @brief Manually begin an NVTX range.
+ *
+ * Explicitly begins an NVTX range and returns a unique handle. To end the
+ * range, pass the handle to `end_range_in<D>()`.
+ *
+ * `nvtx3::start_range(...)` is equivalent to `nvtx3::start_range_in<>(...)` and
+ * `nvtx3::start_range_in<nvtx3::domain::global>(...)`.
+ *
+ * `start_range_in/end_range_in` are the most explicit and lowest level APIs
+ * provided for creating ranges.  Use of `nvtx3::unique_range_in` should be
+ * preferred unless one is unable to tie the range to the lifetime of an object.
+ *
+ * Example:
+ * \code{.cpp}
+ * nvtx3::event_attributes attr{"msg", nvtx3::rgb{127,255,0}};
+ * // Manually begin a range
+ * nvtx3::range_handle h = nvtx3::start_range_in<my_domain>(attr);
+ * ...
+ * nvtx3::end_range_in<my_domain>(h); // End the range
+ * \endcode
+ *
+ * @tparam D Type containing `name` member used to identify the `domain`
+ * to which the range belongs. Else, `domain::global` to indicate that the
+ * global NVTX domain should be used.
+ * @param[in] attr `event_attributes` that describes the desired attributes
+ * of the range.
+ * @return Unique handle to be passed to `end_range_in` to end the range.
+ */
+template <typename D = domain::global>
+NVTX3_NO_DISCARD inline range_handle start_range_in(event_attributes const& attr) noexcept
+{
+#ifndef NVTX_DISABLE
+  return range_handle{nvtxDomainRangeStartEx(domain::get<D>(), attr.get())};
+#else
+  (void)attr;
+  return {};
+#endif
+}
+
+/**
+ * @brief Manually begin an NVTX range.
+ *
+ * Explicitly begins an NVTX range and returns a unique handle. To end the
+ * range, pass the handle to `end_range_in<D>()`.
+ *
+ * `nvtx3::start_range(...)` is equivalent to `nvtx3::start_range_in<>(...)` and
+ * `nvtx3::start_range_in<nvtx3::domain::global>(...)`.
+ *
+ * `start_range_in/end_range_in` are the most explicit and lowest level APIs
+ * provided for creating ranges.  Use of `nvtx3::unique_range_in` should be
+ * preferred unless one is unable to tie the range to the lifetime of an object.
+ *
+ * This overload uses `args...` to construct an  `event_attributes` to
+ * associate with the range.  For more detail, see `event_attributes`.
+ *
+ * Example:
+ * \code{cpp}
+ * // Manually begin a range
+ * nvtx3::range_handle h = nvtx3::start_range_in<D>("msg", nvtx3::rgb{127,255,0});
+ * ...
+ * nvtx3::end_range_in<D>(h); // Ends the range
+ * \endcode
+ *
+ * @tparam D Type containing `name` member used to identify the `domain`
+ * to which the range belongs. Else, `domain::global` to indicate that the
+ * global NVTX domain should be used.
+ * @param[in] args Variadic parameter pack of the arguments for an `event_attributes`.
+ * @return Unique handle to be passed to `end_range` to end the range.
+ */
+template <typename D = domain::global, typename... Args>
+NVTX3_NO_DISCARD inline range_handle start_range_in(Args const&... args) noexcept
+{
+#ifndef NVTX_DISABLE
+  return start_range_in<D>(event_attributes{args...});
+#else
+  detail::silence_unused(args...);
+  return {};
+#endif
+}
+
+/**
+ * @brief Manually begin an NVTX range in the global domain.
+ *
+ * Explicitly begins an NVTX range and returns a unique handle. To end the
+ * range, pass the handle to `end_range()`.
+ *
+ * `nvtx3::start_range(...)` is equivalent to `nvtx3::start_range_in<>(...)` and
+ * `nvtx3::start_range_in<nvtx3::domain::global>(...)`.
+ *
+ * `start_range/end_range` are the most explicit and lowest level APIs
+ * provided for creating ranges.  Use of `nvtx3::unique_range` should be
+ * preferred unless one is unable to tie the range to the lifetime of an object.
+ *
+ * Example:
+ * \code{.cpp}
+ * nvtx3::event_attributes attr{"msg", nvtx3::rgb{127,255,0}};
+ * // Manually begin a range
+ * nvtx3::range_handle h = nvtx3::start_range(attr);
+ * ...
+ * nvtx3::end_range(h); // End the range
+ * \endcode
+ *
+ * @param[in] attr `event_attributes` that describes the desired attributes
+ * of the range.
+ * @return Unique handle to be passed to `end_range_in` to end the range.
+ */
+NVTX3_NO_DISCARD inline range_handle start_range(event_attributes const& attr) noexcept
+{
+#ifndef NVTX_DISABLE
+  return start_range_in<domain::global>(attr);
+#else
+  (void)attr;
+  return {};
+#endif
+}
+
+/**
+ * @brief Manually begin an NVTX range in the global domain.
+ *
+ * Explicitly begins an NVTX range and returns a unique handle. To end the
+ * range, pass the handle to `end_range_in<D>()`.
+ *
+ * `nvtx3::start_range(...)` is equivalent to `nvtx3::start_range_in<>(...)` and
+ * `nvtx3::start_range_in<nvtx3::domain::global>(...)`.
+ *
+ * `start_range_in/end_range_in` are the most explicit and lowest level APIs
+ * provided for creating ranges.  Use of `nvtx3::unique_range_in` should be
+ * preferred unless one is unable to tie the range to the lifetime of an object.
+ *
+ * This overload uses `args...` to construct an  `event_attributes` to
+ * associate with the range.  For more detail, see `event_attributes`.
+ *
+ * Example:
+ * \code{cpp}
+ * // Manually begin a range
+ * nvtx3::range_handle h = nvtx3::start_range("msg", nvtx3::rgb{127,255,0});
+ * ...
+ * nvtx3::end_range(h); // Ends the range
+ * \endcode
+ *
+ * @param[in] args Variadic parameter pack of the arguments for an `event_attributes`.
+ * @return Unique handle to be passed to `end_range` to end the range.
+ */
+template <typename... Args>
+NVTX3_NO_DISCARD inline range_handle start_range(Args const&... args) noexcept
+{
+#ifndef NVTX_DISABLE
+  return start_range_in<domain::global>(args...);
+#else
+  detail::silence_unused(args...);
+  return {};
+#endif
+}
+
+/**
+ * @brief Manually end the range associated with the handle `r` in domain `D`.
+ *
+ * Explicitly ends the NVTX range indicated by the handle `r` returned from a
+ * prior call to `start_range_in<D>`. The range may end on a different thread
+ * from where it began.
+ *
+ * @tparam D Type containing `name` member used to identify the `domain` to
+ * which the range belongs. Else, `domain::global` to indicate that the global
+ * NVTX domain should be used.
+ * @param r Handle to a range started by a prior call to `start_range_in`.
+ *
+ * @warning The domain type specified as template parameter to this function
+ * must be the same that was specified on the associated `start_range_in` call.
+ */
+template <typename D = domain::global>
+inline void end_range_in(range_handle r) noexcept
+{
+#ifndef NVTX_DISABLE
+  nvtxDomainRangeEnd(domain::get<D>(), r.get_value());
+#else
+  (void)r;
+#endif
+}
+
+/**
+ * @brief Manually end the range associated with the handle `r` in the global
+ * domain.
+ *
+ * Explicitly ends the NVTX range indicated by the handle `r` returned from a
+ * prior call to `start_range`. The range may end on a different thread from
+ * where it began.
+ *
+ * @param r Handle to a range started by a prior call to `start_range`.
+ *
+ * @warning The domain type specified as template parameter to this function
+ * must be the same that was specified on the associated `start_range` call.
+ */
+inline void end_range(range_handle r) noexcept
+{
+#ifndef NVTX_DISABLE
+  end_range_in<domain::global>(r);
+#else
+  (void)r;
+#endif
+}
+
+/**
+ * @brief A RAII object for creating a NVTX range within a domain that can
+ * be created and destroyed on different threads.
+ *
+ * When constructed, begins a NVTX range in the specified domain. Upon
+ * destruction, ends the NVTX range.
+ *
+ * Similar to `nvtx3::scoped_range_in`, with a few key differences:
+ * - `unique_range` objects can be destroyed in an order whereas `scoped_range` objects must be
+ *    destroyed in exact reverse creation order
+ * - `unique_range` can start and end on different threads
+ * - `unique_range` is movable
+ * - `unique_range` objects can be constructed as heap objects
+ *
+ * There is extra overhead associated with `unique_range` constructs and therefore use of
+ * `nvtx3::scoped_range_in` should be preferred.
+ *
+ * @tparam D Type containing `name` member used to identify the `domain`
+ * to which the `unique_range_in` belongs. Else, `domain::global` to
+ * indicate that the global NVTX domain should be used.
+ */
+template <typename D = domain::global>
+class NVTX3_MAYBE_UNUSED unique_range_in {
+ public:
+  /**
+   * @brief Construct a new unique_range_in object with the specified event attributes
+   *
+   * Example:
+   * \code{cpp}
+   * nvtx3::event_attributes attr{"msg", nvtx3::rgb{127,255,0}};
+   * nvtx3::unique_range_in<my_domain> range{attr}; // Creates a range with message contents
+   *                                            // "msg" and green color
+   * \endcode
+   *
+   * @param[in] attr `event_attributes` that describes the desired attributes
+   * of the range.
+   */
+  explicit unique_range_in(event_attributes const& attr) noexcept
+    : handle_{start_range_in<D>(attr)}
+  {
+  }
+
+  /**
+   * @brief Constructs a `unique_range_in` from the constructor arguments
+   * of an `event_attributes`.
+   *
+   * Forwards the arguments `args...` to construct an
+   * `event_attributes` object. The `event_attributes` object is then
+   * associated with the `unique_range_in`.
+   *
+   * For more detail, see `event_attributes` documentation.
+   *
+   * Example:
+   * \code{.cpp}
+   * // Creates a range with message "message" and green color
+   * nvtx3::unique_range_in<> r{"message", nvtx3::rgb{127,255,0}};
+   * \endcode
+   *
+   * @param[in] args Variadic parameter pack of arguments to construct an `event_attributes`
+   * associated with this range.
+   */
+  template <typename... Args>
+  explicit unique_range_in(Args const&... args) noexcept
+    : unique_range_in{event_attributes{args...}}
+  {
+  }
+
+  /**
+   * @brief Default constructor creates a `unique_range_in` with no
+   * message, color, payload, nor category.
+   *
+   */
+  constexpr unique_range_in() noexcept : unique_range_in{event_attributes{}} {}
+
+  /**
+   * @brief Destroy the `unique_range_in` ending the range.
+   *
+   */
+  ~unique_range_in() noexcept = default;
+
+  /**
+   * @brief Move constructor allows taking ownership of the NVTX range from
+   * another `unique_range_in`.
+   *
+   * @param other The range to take ownership of
+   */
+  unique_range_in(unique_range_in&& other) noexcept = default;
+
+  /**
+   * @brief Move assignment operator allows taking ownership of an NVTX range
+   * from another `unique_range_in`.
+   *
+   * @param other The range to take ownership of
+   */
+  unique_range_in& operator=(unique_range_in&& other) noexcept = default;
+
+  /// Copy construction is not allowed to prevent multiple objects from owning
+  /// the same range handle
+  unique_range_in(unique_range_in const&) = delete;
+
+  /// Copy assignment is not allowed to prevent multiple objects from owning the
+  /// same range handle
+  unique_range_in& operator=(unique_range_in const&) = delete;
+
+ private:
+
+  struct end_range_handle {
+    using pointer = range_handle;  /// Override the pointer type of the unique_ptr
+    void operator()(range_handle h) const noexcept { end_range_in<D>(h); }
+  };
+
+  /// Range handle used to correlate the start/end of the range
+  std::unique_ptr<range_handle, end_range_handle> handle_;
+};
+
+/**
+ * @brief Alias for a `unique_range_in` in the global NVTX domain.
+ *
+ */
+using unique_range = unique_range_in<domain::global>;
+
+/**
+ * @brief Annotates an instantaneous point in time with a "marker", using the
+ * attributes specified by `attr`.
+ *
+ * Unlike a "range" which has a beginning and an end, a marker is a single event
+ * in an application, such as detecting a problem:
+ *
+ * \code{.cpp}
+ * bool success = do_operation(...);
+ * if (!success) {
+ *    nvtx3::event_attributes attr{"operation failed!", nvtx3::rgb{255,0,0}};
+ *    nvtx3::mark_in<my_domain>(attr);
+ * }
+ * \endcode
+ *
+ * Note that nvtx3::mark_in<D> is a function, not a class like scoped_range_in<D>.
+ *
+ * @tparam D Type containing `name` member used to identify the `domain`
+ * to which the `unique_range_in` belongs. Else, `domain::global` to
+ * indicate that the global NVTX domain should be used.
+ * @param[in] attr `event_attributes` that describes the desired attributes
+ * of the mark.
+ */
+template <typename D = domain::global>
+inline void mark_in(event_attributes const& attr) noexcept
+{
+#ifndef NVTX_DISABLE
+  nvtxDomainMarkEx(domain::get<D>(), attr.get());
+#else
+  (void)(attr);
+#endif
+}
+
+/**
+ * @brief Annotates an instantaneous point in time with a "marker", using the
+ * arguments to construct an `event_attributes`.
+ *
+ * Unlike a "range" which has a beginning and an end, a marker is a single event
+ * in an application, such as detecting a problem:
+ *
+ * \code{.cpp}
+ * bool success = do_operation(...);
+ * if (!success) {
+ *    nvtx3::mark_in<my_domain>("operation failed!", nvtx3::rgb{255,0,0});
+ * }
+ * \endcode
+ *
+ * Note that nvtx3::mark_in<D> is a function, not a class like scoped_range_in<D>.
+ *
+ * Forwards the arguments `args...` to construct an `event_attributes` object.
+ * The attributes are then associated with the marker. For more detail, see
+ * the `event_attributes` documentation.
+ *
+ * @tparam D Type containing `name` member used to identify the `domain`
+ * to which the `unique_range_in` belongs. Else `domain::global` to
+ * indicate that the global NVTX domain should be used.
+ * @param[in] args Variadic parameter pack of arguments to construct an `event_attributes`
+ * associated with this range.
+ *
+ */
+template <typename D = domain::global, typename... Args>
+inline void mark_in(Args const&... args) noexcept
+{
+#ifndef NVTX_DISABLE
+  mark_in<D>(event_attributes{args...});
+#else
+  detail::silence_unused(args...);
+#endif
+}
+
+/**
+ * @brief Annotates an instantaneous point in time with a "marker", using the
+ * attributes specified by `attr`, in the global domain.
+ *
+ * Unlike a "range" which has a beginning and an end, a marker is a single event
+ * in an application, such as detecting a problem:
+ *
+ * \code{.cpp}
+ * bool success = do_operation(...);
+ * if (!success) {
+ *    nvtx3::event_attributes attr{"operation failed!", nvtx3::rgb{255,0,0}};
+ *    nvtx3::mark(attr);
+ * }
+ * \endcode
+ *
+ * Note that nvtx3::mark is a function, not a class like scoped_range.
+ *
+ * @param[in] attr `event_attributes` that describes the desired attributes
+ * of the mark.
+ */
+inline void mark(event_attributes const& attr) noexcept
+{
+#ifndef NVTX_DISABLE
+  mark_in<domain::global>(attr);
+#else
+  (void)attr;
+#endif
+}
+
+/**
+ * @brief Annotates an instantaneous point in time with a "marker", using the
+ * arguments to construct an `event_attributes`, in the global domain.
+ *
+ * Unlike a "range" which has a beginning and an end, a marker is a single event
+ * in an application, such as detecting a problem:
+ *
+ * \code{.cpp}
+ * bool success = do_operation(...);
+ * if (!success) {
+ *    nvtx3::mark("operation failed!", nvtx3::rgb{255,0,0});
+ * }
+ * \endcode
+ *
+ * Note that nvtx3::mark is a function, not a class like scoped_range.
+ *
+ * Forwards the arguments `args...` to construct an `event_attributes` object.
+ * The attributes are then associated with the marker. For more detail, see
+ * the `event_attributes` documentation.
+ *
+ * @param[in] args Variadic parameter pack of arguments to construct an
+ * `event_attributes` associated with this range.
+ *
+ */
+template <typename... Args>
+inline void mark(Args const&... args) noexcept
+{
+#ifndef NVTX_DISABLE
+  mark_in<domain::global>(args...);
+#else
+  detail::silence_unused(args...);
+#endif
+}
+
+}  // namespace NVTX3_MINOR_VERSION_NAMESPACE
+}  // namespace NVTX3_VERSION_NAMESPACE
+} // namespace nvtx3
+
+#ifndef NVTX_DISABLE
+/**
+ * @brief Convenience macro for generating a range in the specified `domain`
+ * from the lifetime of a function
+ *
+ * This macro is useful for generating an NVTX range in `domain` from
+ * the entry point of a function to its exit. It is intended to be the first
+ * line of the function.
+ *
+ * Constructs a static `registered_string_in` using the name of the immediately
+ * enclosing function returned by `__func__` and constructs a
+ * `nvtx3::scoped_range` using the registered function name as the range's
+ * message.
+ *
+ * Example:
+ * \code{.cpp}
+ * struct my_domain{static constexpr char const* name{"my_domain"};};
+ *
+ * void foo(...) {
+ *    NVTX3_FUNC_RANGE_IN(my_domain); // Range begins on entry to foo()
+ *    // do stuff
+ *    ...
+ * } // Range ends on return from foo()
+ * \endcode
+ *
+ * @param[in] D Type containing `name` member used to identify the
+ * `domain` to which the `registered_string_in` belongs. Else,
+ * `domain::global` to  indicate that the global NVTX domain should be used.
+ */
+#define NVTX3_V1_FUNC_RANGE_IN(D)                                                  \
+  static ::nvtx3::v1::registered_string_in<D> const nvtx3_func_name__{__func__};   \
+  static ::nvtx3::v1::event_attributes const nvtx3_func_attr__{nvtx3_func_name__}; \
+  ::nvtx3::v1::scoped_range_in<D> const nvtx3_range__{nvtx3_func_attr__}
+
+/**
+ * @brief Convenience macro for generating a range in the specified `domain`
+ * from the lifetime of a function if the given boolean expression evaluates
+ * to true.
+ *
+ * Similar to `NVTX3_V1_FUNC_RANGE_IN(D)`, the only difference being that
+ * `NVTX3_V1_FUNC_RANGE_IF_IN(D, C)` only generates a range if the given boolean
+ * expression evaluates to true.
+ *
+ * @param[in] D Type containing `name` member used to identify the
+ * `domain` to which the `registered_string_in` belongs. Else,
+ * `domain::global` to indicate that the global NVTX domain should be used.
+ *
+ * @param[in] C Boolean expression used to determine if a range should be
+ * generated.
+ */
+#define NVTX3_V1_FUNC_RANGE_IF_IN(D, C)                                            \
+  ::nvtx3::v1::detail::optional_scoped_range_in<D> optional_nvtx3_range__;         \
+  if (C) {                                                                         \
+    static ::nvtx3::v1::registered_string_in<D> const nvtx3_func_name__{__func__};   \
+    static ::nvtx3::v1::event_attributes const nvtx3_func_attr__{nvtx3_func_name__}; \
+    optional_nvtx3_range__.begin(nvtx3_func_attr__);                               \
+  } (void)0
+#else /* NVTX_DISABLE */
+#define NVTX3_V1_FUNC_RANGE_IN(D) (void)0
+#define NVTX3_V1_FUNC_RANGE_IF_IN(D, C) (void)(C)
+#endif /* NVTX_DISABLE */
+
+/**
+ * @brief Convenience macro for generating a range in the global domain from the
+ * lifetime of a function.
+ *
+ * This macro is useful for generating an NVTX range in the global domain from
+ * the entry point of a function to its exit. It is intended to be the first
+ * line of the function.
+ *
+ * Constructs a static `registered_string_in` using the name of the immediately
+ * enclosing function returned by `__func__` and constructs a
+ * `nvtx3::scoped_range` using the registered function name as the range's
+ * message.
+ *
+ * Example:
+ * \code{.cpp}
+ * void foo(...) {
+ *    NVTX3_FUNC_RANGE(); // Range begins on entry to foo()
+ *    // do stuff
+ *    ...
+ * } // Range ends on return from foo()
+ * \endcode
+ */
+#define NVTX3_V1_FUNC_RANGE() NVTX3_V1_FUNC_RANGE_IN(::nvtx3::v1::domain::global)
+
+/**
+ * @brief Convenience macro for generating a range in the global domain from the
+ * lifetime of a function if the given boolean expression evaluates to true.
+ *
+ * Similar to `NVTX3_V1_FUNC_RANGE()`, the only difference being that
+ * `NVTX3_V1_FUNC_RANGE_IF(C)` only generates a range if the given boolean
+ * expression evaluates to true.
+ *
+ * @param[in] C Boolean expression used to determine if a range should be
+ * generated.
+ */
+#define NVTX3_V1_FUNC_RANGE_IF(C) NVTX3_V1_FUNC_RANGE_IF_IN(::nvtx3::v1::domain::global, C)
+
+// We need another helper macro because the other one will get undefined
+#if __has_cpp_attribute(nodiscard)
+#define NVTX3_V1_NO_DISCARD [[nodiscard]]
+#else
+#define NVTX3_V1_NO_DISCARD
+#endif
+/**
+ * @brief Convenience macro for generating a sspecialization of nvtx3::schema::get
+ * for an existing `struct`.
+ *
+ * Use this macro after your struct to enable the struct to be used as a payload.
+ *
+ * \note This macro must not be used inside a namespace.
+ *
+ * Example:
+ * \code{.cpp}
+ * struct SensorData
+ * {
+ *     int32_t sensorId;
+ *     uint8_t channelId;
+ * };
+ *
+ * NVTX3_DEFINE_SCHEMA_GET(
+ *     my_domain,
+ *     SensorData,
+ *     "SensorEvent",
+ *     NVTX_PAYLOAD_ENTRIES(
+ *         (sensorId, TYPE_INT32, "SensorID"),
+ *         (channelId, TYPE_UINT8, "ChannelID")
+ *     )
+ * )
+ * \endcode
+ *
+ * @param[in] dom The NVTX domain.
+ * @param[in] struct_id The name of the struct.
+ * @param[in] schema_name Name of the payload schema.
+ * @param[in] entries Payload schema entries using NVTX_PAYLOAD_ENTRIES macro.
+ */
+#define NVTX3_V1_DEFINE_SCHEMA_GET(dom, struct_id, schema_name, entries)                                \
+    template <>                                                                                        \
+    NVTX3_V1_NO_DISCARD inline nvtx3::v1::schema const& nvtx3::v1::schema::get<struct_id>() noexcept     \
+    {                                                                                                  \
+        static_assert(                                                                                 \
+            std::is_standard_layout<struct_id>::value,                                                 \
+            "structs used for NVTX3 payload schema must be standard layout");                          \
+        static_assert(                                                                                 \
+            std::is_trivially_copyable<struct_id>::value,                                              \
+            "structs used for NVTX3 payload schema must be trivially copyable");                       \
+        using nvtx_struct_id = struct_id; /* avoids issues with namespaced struct_id */                 \
+        _NVTX_DEFINE_SCHEMA_FOR_STRUCT(nvtx_struct_id, schema_name, static const expr, entries)          \
+        static const schema s{                                                                         \
+            nvtxPayloadSchemaRegister(nvtx3::v1::domain::get<dom>(), &nvtx_struct_id##Attr)};           \
+        return s;                                                                                      \
+    }
+
+/* When inlining this version, versioned macros must have unversioned aliases.
+ * For each NVTX3_Vx_ #define, make an NVTX3_ alias of it here.*/
+#if defined(NVTX3_INLINE_THIS_VERSION)
+/* clang format off */
+#define NVTX3_FUNC_RANGE        NVTX3_V1_FUNC_RANGE
+#define NVTX3_FUNC_RANGE_IF     NVTX3_V1_FUNC_RANGE_IF
+#define NVTX3_FUNC_RANGE_IN     NVTX3_V1_FUNC_RANGE_IN
+#define NVTX3_FUNC_RANGE_IF_IN  NVTX3_V1_FUNC_RANGE_IF_IN
+#define NVTX3_DEFINE_SCHEMA_GET NVTX3_V1_DEFINE_SCHEMA_GET
+/* clang format on */
+#endif
+
+#endif  // NVTX3_CPP_DEFINITIONS_V1_0
+
+/* Add functionality for new minor versions here, by copying the above section enclosed
+ * in #ifndef NVTX3_CPP_DEFINITIONS_Vx_y, and incrementing the minor version.  This code
+ * is an example of how additions for version 1.2 would look, indented for clarity.  Note
+ * that the versioned symbols and macros are always provided, and the unversioned symbols
+ * are only provided if NVTX3_INLINE_THIS_VERSION was defined at the top of this header.
+ *
+ * \code{.cpp}
+ * #ifndef NVTX3_CPP_DEFINITIONS_V1_2
+ * #define NVTX3_CPP_DEFINITIONS_V1_2
+ *     namespace nvtx3 {
+ *         NVTX3_INLINE_IF_REQUESTED namespace NVTX3_VERSION_NAMESPACE {
+ *             class new_class {};
+ *             inline void new_function() {}
+ *         }
+ *     }
+ *
+ *     // Macros must have the major version in their names:
+ *     #define NVTX3_V1_NEW_MACRO_A() ...
+ *     #define NVTX3_V1_NEW_MACRO_B() ...
+ *
+ *     // If inlining, make aliases for the macros with the version number omitted
+ *     #if defined(NVTX3_INLINE_THIS_VERSION)
+ *         #define NVTX3_NEW_MACRO_A NVTX3_V1_NEW_MACRO_A
+ *         #define NVTX3_NEW_MACRO_B NVTX3_V1_NEW_MACRO_B
+ *     #endif
+ * #endif // NVTX3_CPP_DEFINITIONS_V1_2
+ * \endcode
+ */
+
+/* Undefine all temporarily-defined unversioned macros, which would conflict with
+ * subsequent includes of different versions of this header. */
+#undef NVTX3_CPP_VERSION_MAJOR
+#undef NVTX3_CPP_VERSION_MINOR
+#undef NVTX3_CONCAT
+#undef NVTX3_NAMESPACE_FOR
+#undef NVTX3_VERSION_NAMESPACE
+#undef NVTX3_MINOR_NAMESPACE_FOR
+#undef NVTX3_MINOR_VERSION_NAMESPACE
+#undef NVTX3_INLINE_IF_REQUESTED
+#undef NVTX3_CONSTEXPR_IF_CPP14
+#undef NVTX3_MAYBE_UNUSED
+#undef NVTX3_NO_DISCARD
+
+#if defined(NVTX3_INLINE_THIS_VERSION)
+#undef NVTX3_INLINE_THIS_VERSION
+#endif
+
+#if defined(NVTX3_USE_CHECKED_OVERLOADS_FOR_GET_DEFINED_HERE)
+#undef NVTX3_USE_CHECKED_OVERLOADS_FOR_GET_DEFINED_HERE
+#undef NVTX3_USE_CHECKED_OVERLOADS_FOR_GET
+#endif
+
+#if defined(NVTX3_STATIC_ASSERT_DEFINED_HERE)
+#undef NVTX3_STATIC_ASSERT_DEFINED_HERE
+#undef NVTX3_STATIC_ASSERT
+#endif

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtHelperMacros.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtHelperMacros.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+#ifndef NVTX_EXT_HELPER_MACROS_H
+#define NVTX_EXT_HELPER_MACROS_H
+
+#if !defined(NVTX_NULLPTR)
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define NVTX_NULLPTR nullptr
+#else
+#define NVTX_NULLPTR NULL
+#endif
+#endif
+
+/* Combine tokens */
+#define _NVTX_EXT_CONCAT(a, b) a##b
+#define NVTX_EXT_CONCAT(a, b) _NVTX_EXT_CONCAT(a, b)
+
+/* Resolves to the number of arguments passed. */
+#define NVTX_EXT_NUM_ARGS(...) \
+    NVTX_EXT_SELECTA16(__VA_ARGS__, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, throwaway)
+#define NVTX_EXT_SELECTA16(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, ...) a16
+
+/* Cast argument(s) to void to prevent unused variable warnings. */
+#define _NVTX_EXT_VOIDIFY0()
+#define _NVTX_EXT_VOIDIFY1(a1) (void)a1;
+#define _NVTX_EXT_VOIDIFY2(a1, a2) (void)a1; (void)a2;
+#define _NVTX_EXT_VOIDIFY3(a1, a2, a3) (void)a1; (void)a2; (void)a3;
+#define _NVTX_EXT_VOIDIFY4(a1, a2, a3, a4) (void)a1; (void)a2; (void)a3; (void)a4;
+#define _NVTX_EXT_VOIDIFY5(a1, a2, a3, a4, a5) (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+#define _NVTX_EXT_VOIDIFY6(a1, a2, a3, a4, a5, a6) (void)a1; (void)a2; (void)a3; (void)a4; (void)a5; (void)a6;
+
+/* Mark function arguments as unused. */
+#define NVTX_EXT_HELPER_UNUSED_ARGS(...) \
+    NVTX_EXT_CONCAT(_NVTX_EXT_VOIDIFY, NVTX_EXT_NUM_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+#endif /* NVTX_EXT_HELPER_MACROS_H */

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtImpl.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtImpl.h
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#ifndef NVTX_EXT_IMPL_GUARD
+#error Never include this file directly -- it is automatically included by nvToolsExt.h (except when NVTX_NO_IMPL is defined).
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+#ifndef NVTX_EXT_IMPL_H
+#define NVTX_EXT_IMPL_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <wchar.h>
+
+/* ---- Include required platform headers ---- */
+
+#if defined(_WIN32)
+
+#include <windows.h>
+
+#else
+#include <unistd.h>
+
+#if defined(__ANDROID__)
+#include <android/api-level.h>
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+#include <sched.h>
+#endif
+
+#include <sys/types.h>
+#include <limits.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+
+#endif
+
+/* ---- Define macros used in this file ---- */
+
+#ifdef NVTX_DEBUG_PRINT
+#ifdef __ANDROID__
+#include <android/log.h>
+#define NVTX_ERR(...) __android_log_print(ANDROID_LOG_ERROR, "NVTOOLSEXT", __VA_ARGS__);
+#define NVTX_INFO(...) __android_log_print(ANDROID_LOG_INFO, "NVTOOLSEXT", __VA_ARGS__);
+#else
+#include <stdio.h>
+#define NVTX_ERR(...) fprintf(stderr, "NVTX_ERROR: " __VA_ARGS__)
+#define NVTX_INFO(...) fprintf(stderr, "NVTX_INFO: " __VA_ARGS__)
+#endif
+#else /* !defined(NVTX_DEBUG_PRINT) */
+#define NVTX_ERR(...)
+#define NVTX_INFO(...)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef __GNUC__
+#pragma GCC visibility push(hidden)
+#endif
+
+#define NVTX_EXTENSION_FRESH 0    /* Uninitialized extension or function slot */
+#define NVTX_EXTENSION_DISABLED 1 /* Disabled extension or function slot */
+#define NVTX_EXTENSION_STARTING 2 /* Extension is being initialized. */
+#define NVTX_EXTENSION_LOADED 3   /* Extension is initialized successfully. */
+#define NVTX_EXTENSION_INIT_FN_FAILED 4 /* Extension init function returned failure. */
+
+/* Function slots are local to each extension */
+typedef struct nvtxExtGlobals1_t
+{
+    NvtxExtInitializeInjectionFunc_t injectionFnPtr;
+} nvtxExtGlobals1_t;
+
+NVTX_LINKONCE_DEFINE_GLOBAL nvtxExtGlobals1_t NVTX_VERSIONED_IDENTIFIER(nvtxExtGlobals1) =
+{
+    NVTX_NULLPTR
+};
+
+#define NVTX_EXT_INIT_GUARD
+#include "nvtxExtInit.h"
+#undef NVTX_EXT_INIT_GUARD
+
+#ifdef __GNUC__
+#pragma GCC visibility pop
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* NVTX_EXT_IMPL_H */

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtImplPayload_v1.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtImplPayload_v1.h
@@ -1,0 +1,265 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#ifndef NVTX_EXT_IMPL_PAYLOAD_GUARD
+#error Never include this file directly -- it is automatically included by nvToolsExtPayload.h (except when NVTX_NO_IMPL is defined).
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+#define NVTX_EXT_IMPL_GUARD
+#include "nvtxExtImpl.h"
+#undef NVTX_EXT_IMPL_GUARD
+
+#ifndef NVTX_EXT_IMPL_PAYLOAD_V1
+#define NVTX_EXT_IMPL_PAYLOAD_V1
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef NVTX_DISABLE
+
+#include "nvtxExtHelperMacros.h"
+
+#define NVTX_EXT_PAYLOAD_IMPL_FN_V1(ret_type, fn_name, signature, arg_names) \
+NVTX_DECLSPEC ret_type NVTX_API fn_name signature { \
+    NVTX_SET_NAME_MANGLING_OPTIONS \
+    NVTX_EXT_HELPER_UNUSED_ARGS arg_names \
+    NVTX_EXT_FN_RETURN_INVALID(ret_type) \
+}
+
+#define NVTX_EXT_PAYLOAD_IMPL_FN_NOARGS_V1(ret_type, fn_name) \
+NVTX_DECLSPEC ret_type NVTX_API fn_name (void) { \
+    NVTX_SET_NAME_MANGLING_OPTIONS \
+    NVTX_EXT_FN_RETURN_INVALID(ret_type) \
+}
+
+#else /* NVTX_DISABLE */
+
+#include "nvtxExtPayloadTypeInfo.h"
+
+/*
+ * Function slots for the payload extension. First entry is the module state,
+ * initialized to `0` (`NVTX_EXTENSION_FRESH`).
+ */
+#define NVTX_EXT_PAYLOAD_SLOT_COUNT 63
+
+NVTX_LINKONCE_DEFINE_GLOBAL intptr_t
+NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadSlots)[NVTX_EXT_PAYLOAD_SLOT_COUNT + 1]
+    = {0};
+
+/* `NVTX_LINKONCE_FWDDECL_FUNCTION` is used to avoid warnings about missing prototypes. */
+
+/* This helper returns always `1` as `uint8_t`. */
+NVTX_LINKONCE_FWDDECL_FUNCTION uint8_t NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxReturnOne)(void);
+NVTX_LINKONCE_DEFINE_FUNCTION uint8_t NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxReturnOne)(void)
+{
+    return NVTX_STATIC_CAST(uint8_t, 1);
+}
+
+/*
+ * If a tool is attached, but does not handle `nvtxDomainIsEnabled`, the latter
+ * will always return `1` (enabled).
+ */
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxInitIsDomainEnabledFn)(void);
+NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxInitIsDomainEnabledFn)(void)
+{
+    intptr_t* pSlot = &NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadSlots)[NVTX3EXT_CBID_nvtxDomainIsEnabled + 1];
+
+    /* The initialization disables all slots that have not been set by the tool. */
+    if (*pSlot == NVTX_EXTENSION_DISABLED)
+    {
+        intptr_t* moduleState = NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadSlots);
+        int isInitFnSet =
+            NVTX_VERSIONED_IDENTIFIER(nvtxExtGlobals1).injectionFnPtr != NVTX_NULLPTR;
+
+        /* Make `nvtxDomainIsEnabled` return `1`, if the tool does not provide an extension
+           initialization function or if the tool does not handle `nvtxDomainIsEnabled`. */
+        if (*moduleState == NVTX_EXTENSION_DISABLED ||
+            (isInitFnSet && *moduleState != NVTX_EXTENSION_INIT_FN_FAILED))
+        {
+            *pSlot = NVTX_REINTERPRET_CAST(intptr_t, NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxReturnOne));
+        }
+    }
+}
+
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadInitOnce)(void);
+NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadInitOnce)(void)
+{
+    intptr_t* fnSlots = NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadSlots) + 1;
+    nvtxExtModuleSegment_t segment = {
+        0, /* unused (only one segment) */
+        NVTX_EXT_PAYLOAD_SLOT_COUNT,
+        NVTX_NULLPTR /* function slots */
+    };
+
+    nvtxExtModuleInfo_t module_info = {
+        NVTX_VERSION, sizeof(nvtxExtModuleInfo_t),
+        NVTX_EXT_PAYLOAD_MODULEID, NVTX_EXT_PAYLOAD_COMPATID,
+        1, NVTX_NULLPTR, /* number of segments, segments */
+        NVTX_NULLPTR, /* no export function needed */
+        /* bake type sizes and alignment information into program binary */
+        &(NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadTypeInfo))
+    };
+
+    segment.functionSlots = fnSlots;
+    module_info.segments = &segment;
+
+    NVTX_INFO( "%s\n", __FUNCTION__  );
+
+    NVTX_VERSIONED_IDENTIFIER(nvtxExtInitOnce)(&module_info,
+        NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadSlots));
+
+    NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxInitIsDomainEnabledFn)();
+}
+
+#define NVTX_EXT_PAYLOAD_IMPL_FN_V1(ret_type, fn_name, signature, arg_names) \
+typedef ret_type (*fn_name##_impl_fntype)signature; \
+NVTX_DECLSPEC ret_type NVTX_API fn_name signature { \
+    NVTX_SET_NAME_MANGLING_OPTIONS \
+    intptr_t* pSlot = &NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadSlots)[NVTX3EXT_CBID_##fn_name + 1]; \
+    intptr_t slot = *pSlot; \
+    if (slot != NVTX_EXTENSION_DISABLED) { \
+        if (slot != NVTX_EXTENSION_FRESH) { \
+            NVTX_EXT_FN_RETURN (*NVTX_REINTERPRET_CAST(fn_name##_impl_fntype, slot)) arg_names; \
+        } else { \
+            NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadInitOnce)(); \
+            /* Re-read function slot after extension initialization. */ \
+            slot = *pSlot; \
+            if (slot != NVTX_EXTENSION_DISABLED && slot != NVTX_EXTENSION_FRESH) { \
+                NVTX_EXT_FN_RETURN (*NVTX_REINTERPRET_CAST(fn_name##_impl_fntype, slot)) arg_names; \
+            } \
+        } \
+    } \
+    NVTX_EXT_FN_RETURN_INVALID(ret_type) /* No tool attached. */ \
+}
+
+#define NVTX_EXT_PAYLOAD_IMPL_FN_NOARGS_V1(ret_type, fn_name) \
+    NVTX_EXT_PAYLOAD_IMPL_FN_V1(ret_type, fn_name, (void), ())
+
+#endif /* NVTX_DISABLE */
+
+/* Push/pop functions return `NVTX_NO_PUSH_POP_TRACKING` if no tool is attached. */
+#define NVTX_EXT_FN_RETURN return
+#define NVTX_EXT_FN_RETURN_INVALID(rtype) return NVTX_NO_PUSH_POP_TRACKING;
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(int, nvtxRangePushPayload,
+    (nvtxDomainHandle_t domain, const nvtxPayloadData_t* payloadData, size_t count),
+    (domain, payloadData, count))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(int, nvtxRangePopPayload,
+    (nvtxDomainHandle_t domain, const nvtxPayloadData_t* payloadData, size_t count),
+    (domain, payloadData, count))
+
+#undef NVTX_EXT_FN_RETURN
+#undef NVTX_EXT_FN_RETURN_INVALID
+
+/* Non-void functions. */
+#define NVTX_EXT_FN_RETURN return
+#define NVTX_EXT_FN_RETURN_INVALID(rtype) return NVTX_STATIC_CAST(rtype, 0);
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(uint64_t, nvtxPayloadSchemaRegister,
+    (nvtxDomainHandle_t domain, const nvtxPayloadSchemaAttr_t* attr),
+    (domain, attr))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(uint64_t, nvtxPayloadEnumRegister,
+    (nvtxDomainHandle_t domain, const nvtxPayloadEnumAttr_t* attr),
+    (domain, attr))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(nvtxRangeId_t, nvtxRangeStartPayload,
+    (nvtxDomainHandle_t domain, const nvtxPayloadData_t* payloadData, size_t count),
+    (domain, payloadData, count))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(uint8_t, nvtxDomainIsEnabled, (nvtxDomainHandle_t domain), (domain))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(uint64_t, nvtxScopeRegister, (nvtxDomainHandle_t domain,
+    const nvtxScopeAttr_t* attr), (domain, attr))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_NOARGS_V1(int64_t, nvtxTimestampGet)
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(uint64_t, nvtxTimeDomainRegister,
+    (nvtxDomainHandle_t domain, const nvtxTimeDomainAttr_t* attr),
+    (domain, attr))
+
+#undef NVTX_EXT_FN_RETURN
+#undef NVTX_EXT_FN_RETURN_INVALID
+/* END: Non-void functions. */
+
+/* void functions. */
+#define NVTX_EXT_FN_RETURN
+#define NVTX_EXT_FN_RETURN_INVALID(rtype)
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxMarkPayload, (nvtxDomainHandle_t domain,
+    const nvtxPayloadData_t* payloadData, size_t count), (domain, payloadData, count))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxRangeEndPayload, (nvtxDomainHandle_t domain,
+    nvtxRangeId_t id, const nvtxPayloadData_t* payloadData, size_t count),
+    (domain, id, payloadData, count))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxTimerSource,
+    (nvtxDomainHandle_t domain, uint64_t timeDomainId, uint64_t flags, int64_t (*timestampProviderFn)(void)),
+    (domain, timeDomainId, flags, timestampProviderFn))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxTimerSourceWithData,
+    (nvtxDomainHandle_t domain, uint64_t timeDomainId, uint64_t flags, int64_t (*timestampProviderFn)(void* data), void* data),
+    (domain, timeDomainId, flags, timestampProviderFn, data))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxTimeSyncPoint,
+    (nvtxDomainHandle_t domain, uint64_t timeDomainId1, uint64_t timeDomainId2,
+        int64_t timestamp1, int64_t timestamp2),
+    (domain, timeDomainId1, timeDomainId2, timestamp1, timestamp2))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxTimeSyncPointTable,
+    (nvtxDomainHandle_t domain, uint64_t timeDomainIdSrc, uint64_t timeDomainIdDst,
+    const nvtxSyncPoint_t* syncPoints, size_t count),
+    (domain, timeDomainIdSrc, timeDomainIdDst, syncPoints, count))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxTimestampConversionFactor,
+    (nvtxDomainHandle_t domain, uint64_t timeDomainIdSrc, uint64_t timeDomainIdDst,
+        double slope, int64_t timestampSrc, int64_t timestampDst),
+    (domain, timeDomainIdSrc, timeDomainIdDst, slope, timestampSrc, timestampDst))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxEventSubmit,
+    (nvtxDomainHandle_t domain, const nvtxPayloadData_t* payloadData, size_t numPayloads),
+    (domain, payloadData, numPayloads))
+
+NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxEventBatchSubmit, (nvtxDomainHandle_t domain,
+    const nvtxEventBatch_t* eventBatch), (domain, eventBatch))
+
+#undef NVTX_EXT_FN_RETURN
+#undef NVTX_EXT_FN_RETURN_INVALID
+/* END: void functions. */
+
+/* Keep NVTX_EXT_PAYLOAD_IMPL_FN_V1 defined for a future version of this extension. */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* NVTX_EXT_IMPL_PAYLOAD_V1 */

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtPayloadHelperInternal.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtPayloadHelperInternal.h
@@ -1,0 +1,296 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+#ifndef NVTX_EXT_PAYLOAD_HELPER_INTERNAL_H
+#define NVTX_EXT_PAYLOAD_HELPER_INTERNAL_H
+
+/* General helper macros */
+#include "nvtxExtHelperMacros.h"
+
+/* Get variable name with line number (almost unique per file). */
+#define _NVTX_PAYLOAD_DATA_VAR NVTX_EXT_CONCAT(nvtxDFDB,__LINE__)
+
+/* Create real arguments from just pasting tokens next to each other. */
+#define _NVTX_PAYLOAD_PASS_THROUGH(...) __VA_ARGS__
+
+/* Avoid prefixing `NVTX_PAYLOAD_ENTRY_` for nested payloads. */
+#define NVTX_PAYLOAD_ENTRY_THROWAWAY
+#define _NVTX_PAYLOAD_NESTED(id) THROWAWAY id
+
+/*
+ * Create the NVTX binary payloads schema attributes.
+ *
+ * @param struct_id The name of the struct.
+ * @param schema_name The name of the schema.
+ * @param schema_flags Additional schema flags
+ * @param mask_add Fields to be added to the mask.
+ * @param num_entries The number schema entries.
+ */
+#define NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, schema_name, schema_flags, schema_id, mask_add, num_entries) \
+    nvtxPayloadSchemaAttr_t struct_id##Attr = { \
+        /*.fieldMask = */NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE | mask_add \
+            NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | \
+            NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES | \
+            NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE, \
+        /*.name = */schema_name, \
+        /*.type = */NVTX_PAYLOAD_SCHEMA_TYPE_STATIC, \
+        /*.flags = */schema_flags, \
+        /*.entries = */struct_id##Schema, /*.numEntries = */num_entries, \
+        /*.payloadStaticSize = */sizeof(struct_id), \
+        /*.packAlign = */0, /*.schemaId = */schema_id, \
+        /*.extension = */NVTX_NULLPTR};
+
+
+/*****************************************************************/
+/*** Helper for `NVTX_DEFINE_SCHEMA_FOR_STRUCT[_AND_REGISTER]` ***/
+
+/* First part of schema entry for different number of arguments. */
+#define _NVTX_PAYLOAD_SCHEMA_EF2(member, etype) \
+    0, NVTX_PAYLOAD_ENTRY_##etype, NVTX_NULLPTR, NVTX_NULLPTR, 0,
+#define _NVTX_PAYLOAD_SCHEMA_EF3(member, etype, name) \
+    0, NVTX_PAYLOAD_ENTRY_##etype, name, NVTX_NULLPTR, 0,
+#define _NVTX_PAYLOAD_SCHEMA_EF4(member, etype, name, desc) \
+    0, NVTX_PAYLOAD_ENTRY_##etype, name, desc, 0,
+#define _NVTX_PAYLOAD_SCHEMA_EF5(member, etype, name, desc, arraylen) \
+    0, NVTX_PAYLOAD_ENTRY_##etype, name, desc, arraylen,
+#define _NVTX_PAYLOAD_SCHEMA_EF6(member, etype, name, desc, arraylen, flags) \
+    NVTX_PAYLOAD_ENTRY_FLAG_##flags, NVTX_PAYLOAD_ENTRY_##etype, name, desc, arraylen,
+
+#define _NVTX_PAYLOAD_SCHEMA_ENTRY_FRONT(...) \
+    NVTX_EXT_CONCAT(_NVTX_PAYLOAD_SCHEMA_EF, NVTX_EXT_NUM_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+/* Second part of schema entry (append struct member).
+   (At least two arguments are passed (`member` and `etype`). */
+#define _NVTX_PAYLOAD_SCHEMA_ENTRY_END(member, ...) member
+
+/* Resolve to schema entry. `entry` is `(ctype, name, ...)`. */
+#define _NVTX_PAYLOAD_SCHEMA_ENTRY(struct_id, entry) \
+    {_NVTX_PAYLOAD_SCHEMA_ENTRY_FRONT entry \
+    offsetof(struct_id, _NVTX_PAYLOAD_SCHEMA_ENTRY_END entry), \
+    NVTX_NULLPTR, NVTX_NULLPTR},
+
+/* Handle up to 16 schema entries. */
+#define _NVTX_PAYLOAD_SME1(s,e1)      _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1)
+#define _NVTX_PAYLOAD_SME2(s,e1,...)  _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME1(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME3(s,e1,...)  _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME2(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME4(s,e1,...)  _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME3(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME5(s,e1,...)  _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME4(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME6(s,e1,...)  _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME5(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME7(s,e1,...)  _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME6(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME8(s,e1,...)  _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME7(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME9(s,e1,...)  _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME8(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME10(s,e1,...) _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME9(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME11(s,e1,...) _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME10(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME12(s,e1,...) _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME11(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME13(s,e1,...) _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME12(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME14(s,e1,...) _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME13(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME15(s,e1,...) _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME14(s,__VA_ARGS__)
+#define _NVTX_PAYLOAD_SME16(s,e1,...) _NVTX_PAYLOAD_SCHEMA_ENTRY(s,e1) _NVTX_PAYLOAD_SME15(s,__VA_ARGS__)
+
+#define _NVTX_PAYLOAD_SCHEMA_ENTRIES(struct_id, ...) \
+  nvtxPayloadSchemaEntry_t struct_id##Schema[] = { \
+    NVTX_EXT_CONCAT(_NVTX_PAYLOAD_SME, NVTX_EXT_NUM_ARGS(__VA_ARGS__))(struct_id, __VA_ARGS__) \
+    {0, 0, NVTX_NULLPTR, NVTX_NULLPTR, 0, 0, NVTX_NULLPTR, NVTX_NULLPTR} \
+  };
+
+/*
+ * Handle optional parameters for `NVTX_DEFINE_SCHEMA_FOR_STRUCT[_AND_REGISTER]`.
+ */
+#define _NVTX_DEFINE_S4S_6(struct_id, schema_name, prefix, schema_flags, schema_id, entries) \
+    prefix _NVTX_PAYLOAD_SCHEMA_ENTRIES(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+    prefix NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, schema_name, schema_flags, schema_id, \
+        NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_FLAGS | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID |,\
+        NVTX_EXT_NUM_ARGS(_NVTX_PAYLOAD_PASS_THROUGH entries))
+#define _NVTX_DEFINE_S4S_5(struct_id, schema_name, prefix, schema_flags, entries) \
+    prefix _NVTX_PAYLOAD_SCHEMA_ENTRIES(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+    prefix NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, schema_name, schema_flags, 0, \
+        NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_FLAGS |, \
+        NVTX_EXT_NUM_ARGS(_NVTX_PAYLOAD_PASS_THROUGH entries))
+#define _NVTX_DEFINE_S4S_4(struct_id, schema_name, prefix, entries) \
+    prefix _NVTX_PAYLOAD_SCHEMA_ENTRIES(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+    prefix NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, schema_name, NVTX_PAYLOAD_SCHEMA_FLAG_NONE, 0, \
+        NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME |, \
+        NVTX_EXT_NUM_ARGS(_NVTX_PAYLOAD_PASS_THROUGH entries))
+#define _NVTX_DEFINE_S4S_3(struct_id, schema_name, entries) \
+    _NVTX_DEFINE_S4S_4(struct_id, schema_name, /*prefix*/, entries)
+#define _NVTX_DEFINE_S4S_2(struct_id, entries) \
+    _NVTX_PAYLOAD_SCHEMA_ENTRIES(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+    NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, NVTX_NULLPTR, NVTX_PAYLOAD_SCHEMA_FLAG_NONE, 0, ,\
+        NVTX_EXT_NUM_ARGS(_NVTX_PAYLOAD_PASS_THROUGH entries))
+
+#define _NVTX_DEFINE_SCHEMA_FOR_STRUCT(struct_id, ...) \
+    NVTX_EXT_CONCAT(_NVTX_DEFINE_S4S_, \
+        NVTX_EXT_NUM_ARGS(struct_id, __VA_ARGS__))(struct_id, __VA_ARGS__)
+
+/*** END: Helper for `NVTX_PAYLOAD_STATIC_SCHEMA_{DEFINE,SETUP}` ***/
+
+
+/******************************************************************/
+/*** Helper for `NVTX_DEFINE_STRUCT_WITH_SCHEMA[_AND_REGISTER]` ***/
+
+/* Extract struct member for fixed-size arrays. */
+#define _NVTX_PAYLOAD_STRUCT_ARR_MEM1(name) name
+#define _NVTX_PAYLOAD_STRUCT_ARR_MEM2(name, count) name[count]
+
+/* Extract type and member name and handle special case of fixed-size array. */
+#define _NVTX_PAYLOAD_STRUCT_E2(type, member) type member;
+#define _NVTX_PAYLOAD_STRUCT_E3(type, member, etype) type member;
+#define _NVTX_PAYLOAD_STRUCT_E4(type, member, etype, name) type member;
+#define _NVTX_PAYLOAD_STRUCT_E5(type, member, etype, name, desc) type member;
+#define _NVTX_PAYLOAD_STRUCT_E6(type, member, etype, name, desc, arraylen) \
+    type NVTX_EXT_CONCAT(_NVTX_PAYLOAD_STRUCT_ARR_MEM, NVTX_EXT_NUM_ARGS member) member;
+#define _NVTX_PAYLOAD_STRUCT_E7(type, member, etype, name, desc, arraylen, flags) \
+    _NVTX_PAYLOAD_STRUCT_E6(type, member, etype, name, desc, arraylen)
+
+/* Handle different number of arguments per struct entry. */
+#define _NVTX_PAYLOAD_STRUCT_ENTRY_(...) \
+    NVTX_EXT_CONCAT(_NVTX_PAYLOAD_STRUCT_E, NVTX_EXT_NUM_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+/* Handle up to 16 struct members. */
+#define _NVTX_PAYLOAD_STRUCT_ENTRY(entry) _NVTX_PAYLOAD_STRUCT_ENTRY_ entry
+#define _NVTX_PAYLOAD_STRUCT1(e1)       _NVTX_PAYLOAD_STRUCT_ENTRY(e1)
+#define _NVTX_PAYLOAD_STRUCT2(e1, ...)  _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT1(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT3(e1, ...)  _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT2(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT4(e1, ...)  _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT3(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT5(e1, ...)  _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT4(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT6(e1, ...)  _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT5(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT7(e1, ...)  _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT6(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT8(e1, ...)  _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT7(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT9(e1, ...)  _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT8(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT10(e1, ...) _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT9(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT11(e1, ...) _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT10(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT12(e1, ...) _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT11(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT13(e1, ...) _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT12(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT14(e1, ...) _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT13(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT15(e1, ...) _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT14(__VA_ARGS__)
+#define _NVTX_PAYLOAD_STRUCT16(e1, ...) _NVTX_PAYLOAD_STRUCT_ENTRY(e1) _NVTX_PAYLOAD_STRUCT15(__VA_ARGS__)
+
+/* Generate the typedef. */
+#define _NVTX_PAYLOAD_TYPEDEF_STRUCT(struct_id, ...) \
+  typedef struct { \
+      NVTX_EXT_CONCAT(_NVTX_PAYLOAD_STRUCT, NVTX_EXT_NUM_ARGS(__VA_ARGS__))(__VA_ARGS__) \
+  } struct_id;
+
+/* Generate first part of the schema entry. */
+#define _NVTX_PAYLOAD_INIT_SCHEMA_N3(type, memberId, etype) \
+    0, NVTX_PAYLOAD_ENTRY_##etype, NVTX_NULLPTR, NVTX_NULLPTR, 0,
+#define _NVTX_PAYLOAD_INIT_SCHEMA_N4(type, memberId, etype, name) \
+    0, NVTX_PAYLOAD_ENTRY_##etype, name, NVTX_NULLPTR, 0,
+#define _NVTX_PAYLOAD_INIT_SCHEMA_N5(type, memberId, etype, name, desc) \
+    0, NVTX_PAYLOAD_ENTRY_##etype, name, desc, 0,
+#define _NVTX_PAYLOAD_INIT_SCHEMA_N6(type, memberId, etype, name, desc, arraylen) \
+    0, NVTX_PAYLOAD_ENTRY_##etype, name, desc, arraylen,
+#define _NVTX_PAYLOAD_INIT_SCHEMA_N7(type, memberId, etype, name, desc, arraylen, flags) \
+    NVTX_PAYLOAD_ENTRY_FLAG_##flags, NVTX_PAYLOAD_ENTRY_##etype, name, desc, arraylen,
+
+#define _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY_FRONT(...) \
+    NVTX_EXT_CONCAT(_NVTX_PAYLOAD_INIT_SCHEMA_N, NVTX_EXT_NUM_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+#define _NVTX_PAYLOAD_ARRAY_MEMBER1(name) name
+#define _NVTX_PAYLOAD_ARRAY_MEMBER2(name, count) name
+
+/* Resolve to last part of schema entry (append struct member). */
+#define _NVTX_PAYLOAD_INIT_SCHEMA_NX3(type, memberId, ...) memberId
+#define _NVTX_PAYLOAD_INIT_SCHEMA_NX4(type, memberId, ...) memberId
+#define _NVTX_PAYLOAD_INIT_SCHEMA_NX5(type, memberId, ...) memberId
+#define _NVTX_PAYLOAD_INIT_SCHEMA_NX6(type, memberId, ...) \
+    NVTX_EXT_CONCAT(_NVTX_PAYLOAD_ARRAY_MEMBER, NVTX_EXT_NUM_ARGS memberId) memberId
+#define _NVTX_PAYLOAD_INIT_SCHEMA_NX7(type, memberId, ...) \
+    _NVTX_PAYLOAD_INIT_SCHEMA_NX6(type, memberId, __VA_ARGS__)
+
+#define _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY_END(...) \
+    NVTX_EXT_CONCAT(_NVTX_PAYLOAD_INIT_SCHEMA_NX, NVTX_EXT_NUM_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+/* Resolve to schema entry. `entry` is `(ctype, name, ...)`. */
+#define _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(struct_id, entry) \
+    {_NVTX_PAYLOAD_SCHEMA_INIT_ENTRY_FRONT entry \
+    offsetof(struct_id, _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY_END entry)},
+
+/* Handle up to 16 schema entries. */
+#define _NVTX_PAYLOAD_INIT_SME1(s, e1)       _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1)
+#define _NVTX_PAYLOAD_INIT_SME2(s, e1, ...)  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME1(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME3(s, e1, ...)  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME2(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME4(s, e1, ...)  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME3(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME5(s, e1, ...)  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME4(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME6(s, e1, ...)  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME5(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME7(s, e1, ...)  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME6(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME8(s, e1, ...)  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME7(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME9(s, e1, ...)  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME8(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME10(s, e1, ...) _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME9(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME11(s, e1, ...) _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME10(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME12(s, e1, ...) _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME11(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME13(s, e1, ...) _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME12(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME14(s, e1, ...) _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME13(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME15(s, e1, ...) _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME14(s, __VA_ARGS__)
+#define _NVTX_PAYLOAD_INIT_SME16(s, e1, ...) _NVTX_PAYLOAD_SCHEMA_INIT_ENTRY(s, e1) _NVTX_PAYLOAD_INIT_SME15(s, __VA_ARGS__)
+
+#define _NVTX_PAYLOAD_SCHEMA_INIT_ENTRIES(struct_id, ...) \
+  nvtxPayloadSchemaEntry_t struct_id##Schema[] = { \
+    NVTX_EXT_CONCAT(_NVTX_PAYLOAD_INIT_SME, NVTX_EXT_NUM_ARGS(__VA_ARGS__))(struct_id, __VA_ARGS__) \
+    {0, 0, NVTX_NULLPTR, NVTX_NULLPTR, 0, 0, NVTX_NULLPTR, NVTX_NULLPTR} \
+  };
+
+/*
+ * Handle optional parameters for `NVTX_DEFINE_STRUCT_WITH_SCHEMA[_AND_REGISTER]`.
+ */
+#define _NVTX_DEFINE_SWS_6(struct_id, schema_name, prefix, schema_flags, schema_id, entries) \
+  _NVTX_PAYLOAD_TYPEDEF_STRUCT(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+  prefix _NVTX_PAYLOAD_SCHEMA_INIT_ENTRIES(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+  prefix NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, schema_name, schema_flags, schema_id, \
+      NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_FLAGS | \
+      NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID |, \
+      NVTX_EXT_NUM_ARGS(_NVTX_PAYLOAD_PASS_THROUGH entries))
+#define _NVTX_DEFINE_SWS_5(struct_id, schema_name, prefix, schema_flags, entries) \
+  _NVTX_PAYLOAD_TYPEDEF_STRUCT(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+  prefix _NVTX_PAYLOAD_SCHEMA_INIT_ENTRIES(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+  prefix NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, schema_name, schema_flags, 0, \
+      NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_FLAGS |, \
+      NVTX_EXT_NUM_ARGS(_NVTX_PAYLOAD_PASS_THROUGH entries))
+#define _NVTX_DEFINE_SWS_4(struct_id, schema_name, prefix, entries) \
+  _NVTX_PAYLOAD_TYPEDEF_STRUCT(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+  prefix _NVTX_PAYLOAD_SCHEMA_INIT_ENTRIES(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+  prefix NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, schema_name, NVTX_PAYLOAD_SCHEMA_FLAG_NONE, 0, \
+      NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME |, \
+      NVTX_EXT_NUM_ARGS(_NVTX_PAYLOAD_PASS_THROUGH entries))
+#define _NVTX_DEFINE_SWS_3(struct_id, schema_name, entries) \
+  _NVTX_DEFINE_SWS_4(struct_id, schema_name, /* no prefix */, entries)
+#define _NVTX_DEFINE_SWS_2(struct_id, entries) \
+  _NVTX_PAYLOAD_TYPEDEF_STRUCT(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+  _NVTX_PAYLOAD_SCHEMA_INIT_ENTRIES(struct_id, _NVTX_PAYLOAD_PASS_THROUGH entries) \
+  NVTX_PAYLOAD_SCHEMA_ATTR(struct_id, NVTX_NULLPTR, NVTX_PAYLOAD_SCHEMA_FLAG_NONE, 0, , \
+      NVTX_EXT_NUM_ARGS(_NVTX_PAYLOAD_PASS_THROUGH entries))
+
+#define _NVTX_DEFINE_STRUCT_WITH_SCHEMA(struct_id, ...) \
+    NVTX_EXT_CONCAT(_NVTX_DEFINE_SWS_, \
+        NVTX_EXT_NUM_ARGS(struct_id, __VA_ARGS__))(struct_id, __VA_ARGS__)
+
+/*** END: Helper for `NVTX_PAYLOAD_STATIC_SCHEMA_{INIT,CREATE}` */
+
+#endif /* NVTX_EXT_PAYLOAD_HELPER_INTERNAL_H */

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtPayloadTypeInfo.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtPayloadTypeInfo.h
@@ -1,0 +1,189 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#ifndef NVTX_EXT_IMPL_PAYLOAD_GUARD
+#error Never include this file directly -- it is automatically included by nvToolsExtPayload.h (except when NVTX_NO_IMPL is defined).
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+typedef void* nvtx_payload_pointer_type;
+
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+#ifndef __APPLE__
+#include <uchar.h>
+#endif
+#include <stdalign.h>
+#endif
+
+/* `char8_t` is available as of C++20 or C23 */
+#if ((defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || (defined(__cplusplus) && __cplusplus >= 201811L)) && !defined(__APPLE__)
+#define NVTX_HAVE_CHAR8 1
+#else
+#define NVTX_HAVE_CHAR8 0
+#endif
+
+/* `char16_t` and `char32_t` are available as of C++11 or C11 */
+#if ((defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || (defined(__cplusplus) && __cplusplus >= 200704L)) && !defined(__APPLE__)
+#define NVTX_HAVE_CHAR16_CHAR32 1
+#else
+#define NVTX_HAVE_CHAR16_CHAR32 0
+#endif
+
+/* `alignof` is available as of C11 or C++11. */
+#if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)) || (defined(__cplusplus) && __cplusplus >= 201103L)
+
+#define nvtx_alignof(type) alignof(type)
+#define nvtx_alignof2(type,tname) alignof(type)
+
+#else /* (__STDC_VERSION__ >= 201112L) || (__cplusplus >= 201103L) */
+
+/* Create helper structs to determine type alignment. */
+#define MKTYPEDEF(type) typedef struct {char c; type d;} _nvtx_##type
+#define MKTYPEDEF2(type,tname) typedef struct {char c; type d;} _nvtx_##tname
+
+MKTYPEDEF(char);
+MKTYPEDEF2(unsigned char, uchar);
+MKTYPEDEF(short);
+MKTYPEDEF2(unsigned short, ushort);
+MKTYPEDEF(int);
+MKTYPEDEF2(unsigned int, uint);
+MKTYPEDEF(long);
+MKTYPEDEF2(unsigned long, ulong);
+MKTYPEDEF2(long long, longlong);
+MKTYPEDEF2(unsigned long long, ulonglong);
+
+MKTYPEDEF(int8_t);
+MKTYPEDEF(uint8_t);
+MKTYPEDEF(int16_t);
+MKTYPEDEF(uint16_t);
+MKTYPEDEF(int32_t);
+MKTYPEDEF(uint32_t);
+MKTYPEDEF(int64_t);
+MKTYPEDEF(uint64_t);
+
+MKTYPEDEF(float);
+MKTYPEDEF(double);
+MKTYPEDEF2(long double, longdouble);
+
+MKTYPEDEF(size_t);
+MKTYPEDEF(nvtx_payload_pointer_type);
+
+MKTYPEDEF(wchar_t);
+
+#if NVTX_HAVE_CHAR8
+    MKTYPEDEF(char8_t);
+#endif
+
+#if NVTX_HAVE_CHAR16_CHAR32
+    MKTYPEDEF(char16_t);
+    MKTYPEDEF(char32_t);
+#endif
+
+/* C requires to include stddef.h to use `offsetof` */
+#ifndef __cplusplus
+#include <stddef.h>
+#endif
+
+#define nvtx_alignof(tname) offsetof(_nvtx_##tname, d)
+#define nvtx_alignof2(type, tname) offsetof(_nvtx_##tname, d)
+
+#endif /*  __STDC_VERSION__ >= 201112L */
+
+#undef MKTYPEDEF
+#undef MKTYPEDEF2
+
+/*
+ * Helper array to get the alignment for each predefined C/C++ language type.
+ * The order of entries must match the values in`enum nvtxPayloadSchemaEntryType`.
+ *
+ * In C++, `const` variables use internal linkage by default, but we need it to
+ * be public (extern) since weak declarations must be public.
+ */
+NVTX_LINKONCE_DEFINE_GLOBAL
+#ifdef __cplusplus
+extern
+#endif
+const nvtxPayloadEntryTypeInfo_t
+NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadTypeInfo)[NVTX_PAYLOAD_ENTRY_TYPE_INFO_ARRAY_SIZE] =
+{
+    /* The first entry contains this array's length and the size of each entry in this array. */
+    {NVTX_PAYLOAD_ENTRY_TYPE_INFO_ARRAY_SIZE, sizeof(nvtxPayloadEntryTypeInfo_t)},
+
+    /*** C integer types ***/
+    /* NVTX_PAYLOAD_ENTRY_TYPE_CHAR */   {sizeof(char), nvtx_alignof(char)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_UCHAR */  {sizeof(unsigned char), nvtx_alignof2(unsigned char, uchar)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_SHORT */  {sizeof(short), nvtx_alignof(short)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_USHORT */ {sizeof(unsigned short), nvtx_alignof2(unsigned short, ushort)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_INT */    {sizeof(int), nvtx_alignof(int)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_UINT */   {sizeof(unsigned int), nvtx_alignof2(unsigned int, uint)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_LONG */   {sizeof(long), nvtx_alignof(long)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_ULONG */  {sizeof(unsigned long), nvtx_alignof2(unsigned long, ulong)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_LONGLONG */  {sizeof(long long), nvtx_alignof2(long long, longlong)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_ULONGLONG */ {sizeof(unsigned long long), nvtx_alignof2(unsigned long long,ulonglong)},
+
+    /*** Integer types with explicit size ***/
+    /* NVTX_PAYLOAD_ENTRY_TYPE_INT8 */   {sizeof(int8_t),   nvtx_alignof(int8_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_UINT8 */  {sizeof(uint8_t),  nvtx_alignof(uint8_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_INT16 */  {sizeof(int16_t),  nvtx_alignof(int16_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_UINT16 */ {sizeof(uint16_t), nvtx_alignof(uint16_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_INT32 */  {sizeof(int32_t),  nvtx_alignof(int32_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_UINT32 */ {sizeof(uint32_t), nvtx_alignof(uint32_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_INT64 */  {sizeof(int64_t),  nvtx_alignof(int64_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_UINT64 */ {sizeof(uint64_t), nvtx_alignof(uint64_t)},
+
+    /*** C floating point types ***/
+    /* NVTX_PAYLOAD_ENTRY_TYPE_FLOAT */      {sizeof(float),       nvtx_alignof(float)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE */     {sizeof(double),      nvtx_alignof(double)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_LONGDOUBLE */ {sizeof(long double), nvtx_alignof2(long double, longdouble)},
+
+    /* NVTX_PAYLOAD_ENTRY_TYPE_SIZE */    {sizeof(size_t),       nvtx_alignof(size_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_ADDRESS */ {sizeof(nvtx_payload_pointer_type), nvtx_alignof(nvtx_payload_pointer_type)},
+
+    /*** Special character types ***/
+    /* NVTX_PAYLOAD_ENTRY_TYPE_WCHAR */ {sizeof(wchar_t), nvtx_alignof(wchar_t)},
+
+#if NVTX_HAVE_CHAR8
+    /* NVTX_PAYLOAD_ENTRY_TYPE_CHAR8 */ {sizeof(char8_t), nvtx_alignof(char8_t)},
+#else
+    /* NVTX_PAYLOAD_ENTRY_TYPE_CHAR8 */ {0, 0},
+#endif
+
+#if NVTX_HAVE_CHAR16_CHAR32
+    /* NVTX_PAYLOAD_ENTRY_TYPE_CHAR16 */ {sizeof(char16_t), nvtx_alignof(char16_t)},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_CHAR32 */ {sizeof(char32_t), nvtx_alignof(char32_t)}
+#else
+    /* NVTX_PAYLOAD_ENTRY_TYPE_CHAR16 */ {0, 0},
+    /* NVTX_PAYLOAD_ENTRY_TYPE_CHAR32 */ {0, 0}
+#endif
+};
+
+#undef nvtx_alignof
+#undef nvtx_alignof2
+#undef NVTX_HAVE_CHAR8
+#undef NVTX_HAVE_CHAR16_CHAR32

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtTypes.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxExtTypes.h
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#ifndef NVTX_EXT_TYPES_GUARD
+#error Never include this file directly -- it is automatically included by nvToolsExt[EXTENSION].h.
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+/* This header defines types which are used by the internal implementation
+*  of NVTX and callback subscribers.  API clients do not use these types,
+*  so they are defined here instead of in nvToolsExt.h to clarify they are
+*  not part of the NVTX client API. */
+
+#ifndef NVTXEXTTYPES_H
+#define NVTXEXTTYPES_H
+
+typedef intptr_t (NVTX_API * NvtxExtGetExportFunction_t)(uint32_t exportFunctionId);
+
+typedef struct nvtxExtModuleSegment_t
+{
+    size_t segmentId;
+    size_t slotCount;
+    intptr_t* functionSlots;
+} nvtxExtModuleSegment_t;
+
+typedef struct nvtxExtModuleInfo_t
+{
+    uint16_t nvtxVer;
+    uint16_t structSize;
+    uint16_t moduleId;
+    uint16_t compatId;
+    size_t segmentsCount;
+    nvtxExtModuleSegment_t* segments;
+    NvtxExtGetExportFunction_t getExportFunction;
+    const void* extInfo;
+} nvtxExtModuleInfo_t;
+
+typedef int (NVTX_API * NvtxExtInitializeInjectionFunc_t)(nvtxExtModuleInfo_t* moduleInfo);
+
+#endif /* NVTXEXTTYPES_H */

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxImpl.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxImpl.h
@@ -1,0 +1,464 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#ifndef NVTX_IMPL_GUARD
+#error Never include this file directly -- it is automatically included by nvToolsExt.h (except when NVTX_NO_IMPL is defined).
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <wchar.h>
+
+/* ---- Include required platform headers ---- */
+
+#if defined(_WIN32)
+
+#include <windows.h>
+
+#else
+#include <unistd.h>
+
+#if defined(__ANDROID__)
+#include <android/api-level.h>
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+#include <sched.h>
+#endif
+
+#include <sys/types.h>
+#include <limits.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+
+#endif
+
+/* ---- Define macros used in this file ---- */
+
+#define NVTX_INIT_STATE_FRESH 0
+#define NVTX_INIT_STATE_STARTED 1
+#define NVTX_INIT_STATE_COMPLETE 2
+
+#ifdef NVTX_DEBUG_PRINT
+#ifdef __ANDROID__
+#include <android/log.h>
+#define NVTX_ERR(...) __android_log_print(ANDROID_LOG_ERROR, "NVTOOLSEXT", __VA_ARGS__);
+#define NVTX_INFO(...) __android_log_print(ANDROID_LOG_INFO, "NVTOOLSEXT", __VA_ARGS__);
+#else
+#include <stdio.h>
+#define NVTX_ERR(...) fprintf(stderr, "NVTX_ERROR: " __VA_ARGS__)
+#define NVTX_INFO(...) fprintf(stderr, "NVTX_INFO: " __VA_ARGS__)
+#endif
+#else /* !defined(NVTX_DEBUG_PRINT) */
+#define NVTX_ERR(...)
+#define NVTX_INFO(...)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifdef __GNUC__
+#pragma GCC visibility push(hidden)
+#endif
+
+/* ---- Forward declare all functions referenced in globals ---- */
+
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_VERSIONED_IDENTIFIER(nvtxInitOnce)(void);
+NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxEtiGetModuleFunctionTable)(
+    NvtxCallbackModule callback_module,
+    NvtxFunctionTable* out_table,
+    unsigned int* out_size);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxEtiSetInjectionNvtxVersion)(
+    uint32_t version);
+NVTX_LINKONCE_FWDDECL_FUNCTION const void* NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxGetExportTable)(
+    uint32_t exportTableId);
+
+#include "nvtxInitDecls.h"
+
+/* ---- Define all globals ---- */
+
+typedef struct nvtxGlobals_t
+{
+    volatile unsigned int initState;
+    NvtxExportTableCallbacks etblCallbacks;
+    NvtxExportTableVersionInfo etblVersionInfo;
+
+    /* Implementation function pointers */
+    nvtxMarkEx_impl_fntype nvtxMarkEx_impl_fnptr;
+    nvtxMarkA_impl_fntype nvtxMarkA_impl_fnptr;
+    nvtxMarkW_impl_fntype nvtxMarkW_impl_fnptr;
+    nvtxRangeStartEx_impl_fntype nvtxRangeStartEx_impl_fnptr;
+    nvtxRangeStartA_impl_fntype nvtxRangeStartA_impl_fnptr;
+    nvtxRangeStartW_impl_fntype nvtxRangeStartW_impl_fnptr;
+    nvtxRangeEnd_impl_fntype nvtxRangeEnd_impl_fnptr;
+    nvtxRangePushEx_impl_fntype nvtxRangePushEx_impl_fnptr;
+    nvtxRangePushA_impl_fntype nvtxRangePushA_impl_fnptr;
+    nvtxRangePushW_impl_fntype nvtxRangePushW_impl_fnptr;
+    nvtxRangePop_impl_fntype nvtxRangePop_impl_fnptr;
+    nvtxNameCategoryA_impl_fntype nvtxNameCategoryA_impl_fnptr;
+    nvtxNameCategoryW_impl_fntype nvtxNameCategoryW_impl_fnptr;
+    nvtxNameOsThreadA_impl_fntype nvtxNameOsThreadA_impl_fnptr;
+    nvtxNameOsThreadW_impl_fntype nvtxNameOsThreadW_impl_fnptr;
+
+    nvtxNameCuDeviceA_fakeimpl_fntype nvtxNameCuDeviceA_impl_fnptr;
+    nvtxNameCuDeviceW_fakeimpl_fntype nvtxNameCuDeviceW_impl_fnptr;
+    nvtxNameCuContextA_fakeimpl_fntype nvtxNameCuContextA_impl_fnptr;
+    nvtxNameCuContextW_fakeimpl_fntype nvtxNameCuContextW_impl_fnptr;
+    nvtxNameCuStreamA_fakeimpl_fntype nvtxNameCuStreamA_impl_fnptr;
+    nvtxNameCuStreamW_fakeimpl_fntype nvtxNameCuStreamW_impl_fnptr;
+    nvtxNameCuEventA_fakeimpl_fntype nvtxNameCuEventA_impl_fnptr;
+    nvtxNameCuEventW_fakeimpl_fntype nvtxNameCuEventW_impl_fnptr;
+
+    nvtxNameClDeviceA_fakeimpl_fntype nvtxNameClDeviceA_impl_fnptr;
+    nvtxNameClDeviceW_fakeimpl_fntype nvtxNameClDeviceW_impl_fnptr;
+    nvtxNameClContextA_fakeimpl_fntype nvtxNameClContextA_impl_fnptr;
+    nvtxNameClContextW_fakeimpl_fntype nvtxNameClContextW_impl_fnptr;
+    nvtxNameClCommandQueueA_fakeimpl_fntype nvtxNameClCommandQueueA_impl_fnptr;
+    nvtxNameClCommandQueueW_fakeimpl_fntype nvtxNameClCommandQueueW_impl_fnptr;
+    nvtxNameClMemObjectA_fakeimpl_fntype nvtxNameClMemObjectA_impl_fnptr;
+    nvtxNameClMemObjectW_fakeimpl_fntype nvtxNameClMemObjectW_impl_fnptr;
+    nvtxNameClSamplerA_fakeimpl_fntype nvtxNameClSamplerA_impl_fnptr;
+    nvtxNameClSamplerW_fakeimpl_fntype nvtxNameClSamplerW_impl_fnptr;
+    nvtxNameClProgramA_fakeimpl_fntype nvtxNameClProgramA_impl_fnptr;
+    nvtxNameClProgramW_fakeimpl_fntype nvtxNameClProgramW_impl_fnptr;
+    nvtxNameClEventA_fakeimpl_fntype nvtxNameClEventA_impl_fnptr;
+    nvtxNameClEventW_fakeimpl_fntype nvtxNameClEventW_impl_fnptr;
+
+    nvtxNameCudaDeviceA_fakeimpl_fntype nvtxNameCudaDeviceA_impl_fnptr;
+    nvtxNameCudaDeviceW_fakeimpl_fntype nvtxNameCudaDeviceW_impl_fnptr;
+    nvtxNameCudaStreamA_fakeimpl_fntype nvtxNameCudaStreamA_impl_fnptr;
+    nvtxNameCudaStreamW_fakeimpl_fntype nvtxNameCudaStreamW_impl_fnptr;
+    nvtxNameCudaEventA_fakeimpl_fntype nvtxNameCudaEventA_impl_fnptr;
+    nvtxNameCudaEventW_fakeimpl_fntype nvtxNameCudaEventW_impl_fnptr;
+
+    nvtxDomainMarkEx_impl_fntype nvtxDomainMarkEx_impl_fnptr;
+    nvtxDomainRangeStartEx_impl_fntype nvtxDomainRangeStartEx_impl_fnptr;
+    nvtxDomainRangeEnd_impl_fntype nvtxDomainRangeEnd_impl_fnptr;
+    nvtxDomainRangePushEx_impl_fntype nvtxDomainRangePushEx_impl_fnptr;
+    nvtxDomainRangePop_impl_fntype nvtxDomainRangePop_impl_fnptr;
+    nvtxDomainResourceCreate_impl_fntype nvtxDomainResourceCreate_impl_fnptr;
+    nvtxDomainResourceDestroy_impl_fntype nvtxDomainResourceDestroy_impl_fnptr;
+    nvtxDomainNameCategoryA_impl_fntype nvtxDomainNameCategoryA_impl_fnptr;
+    nvtxDomainNameCategoryW_impl_fntype nvtxDomainNameCategoryW_impl_fnptr;
+    nvtxDomainRegisterStringA_impl_fntype nvtxDomainRegisterStringA_impl_fnptr;
+    nvtxDomainRegisterStringW_impl_fntype nvtxDomainRegisterStringW_impl_fnptr;
+    nvtxDomainCreateA_impl_fntype nvtxDomainCreateA_impl_fnptr;
+    nvtxDomainCreateW_impl_fntype nvtxDomainCreateW_impl_fnptr;
+    nvtxDomainDestroy_impl_fntype nvtxDomainDestroy_impl_fnptr;
+    nvtxInitialize_impl_fntype nvtxInitialize_impl_fnptr;
+
+    nvtxDomainSyncUserCreate_fakeimpl_fntype nvtxDomainSyncUserCreate_impl_fnptr;
+    nvtxDomainSyncUserDestroy_fakeimpl_fntype nvtxDomainSyncUserDestroy_impl_fnptr;
+    nvtxDomainSyncUserAcquireStart_fakeimpl_fntype nvtxDomainSyncUserAcquireStart_impl_fnptr;
+    nvtxDomainSyncUserAcquireFailed_fakeimpl_fntype nvtxDomainSyncUserAcquireFailed_impl_fnptr;
+    nvtxDomainSyncUserAcquireSuccess_fakeimpl_fntype nvtxDomainSyncUserAcquireSuccess_impl_fnptr;
+    nvtxDomainSyncUserReleasing_fakeimpl_fntype nvtxDomainSyncUserReleasing_impl_fnptr;
+
+    /* Tables of function pointers -- Extra null added to the end to ensure
+    *  a crash instead of silent corruption if a tool reads off the end. */
+    NvtxFunctionPointer* functionTable_CORE  [NVTX_CBID_CORE_SIZE   + 1];
+    NvtxFunctionPointer* functionTable_CUDA  [NVTX_CBID_CUDA_SIZE   + 1];
+    NvtxFunctionPointer* functionTable_OPENCL[NVTX_CBID_OPENCL_SIZE + 1];
+    NvtxFunctionPointer* functionTable_CUDART[NVTX_CBID_CUDART_SIZE + 1];
+    NvtxFunctionPointer* functionTable_CORE2 [NVTX_CBID_CORE2_SIZE  + 1];
+    NvtxFunctionPointer* functionTable_SYNC  [NVTX_CBID_SYNC_SIZE   + 1];
+} nvtxGlobals_t;
+
+#define NVTX_GLOBAL_TABLE_ENTRY(name) ( NVTX_REINTERPRET_CAST(NvtxFunctionPointer*, &NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).name ## _impl_fnptr ) )
+
+NVTX_LINKONCE_DEFINE_GLOBAL nvtxGlobals_t NVTX_VERSIONED_IDENTIFIER(nvtxGlobals) =
+{
+    NVTX_INIT_STATE_FRESH,
+
+    {
+        sizeof(NvtxExportTableCallbacks),
+        NVTX_VERSIONED_IDENTIFIER(nvtxEtiGetModuleFunctionTable)
+    },
+    {
+        sizeof(NvtxExportTableVersionInfo),
+        NVTX_VERSION,
+        0,
+        NVTX_VERSIONED_IDENTIFIER(nvtxEtiSetInjectionNvtxVersion)
+    },
+
+    /* Implementation function pointers */
+    NVTX_VERSIONED_IDENTIFIER(nvtxMarkEx_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxMarkA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxMarkW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxRangeStartEx_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxRangeStartA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxRangeStartW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxRangeEnd_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxRangePushEx_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxRangePushA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxRangePushW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxRangePop_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCategoryA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCategoryW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameOsThreadA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameOsThreadW_impl_init),
+
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCuDeviceA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCuDeviceW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCuContextA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCuContextW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCuStreamA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCuStreamW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCuEventA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCuEventW_impl_init),
+
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClDeviceA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClDeviceW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClContextA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClContextW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClCommandQueueA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClCommandQueueW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClMemObjectA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClMemObjectW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClSamplerA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClSamplerW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClProgramA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClProgramW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClEventA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameClEventW_impl_init),
+
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaDeviceA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaDeviceW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaStreamA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaStreamW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaEventA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaEventW_impl_init),
+
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainMarkEx_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainRangeStartEx_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainRangeEnd_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainRangePushEx_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainRangePop_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainResourceCreate_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainResourceDestroy_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainNameCategoryA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainNameCategoryW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainRegisterStringA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainRegisterStringW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainCreateA_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainCreateW_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainDestroy_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxInitialize_impl_init),
+
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserCreate_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserDestroy_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserAcquireStart_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserAcquireFailed_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserAcquireSuccess_impl_init),
+    NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserReleasing_impl_init),
+
+    /* Tables of function pointers */
+    {
+        NVTX_NULLPTR,
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxMarkEx),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxMarkA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxMarkW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxRangeStartEx),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxRangeStartA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxRangeStartW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxRangeEnd),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxRangePushEx),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxRangePushA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxRangePushW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxRangePop),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCategoryA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCategoryW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameOsThreadA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameOsThreadW),
+        NVTX_NULLPTR
+    },
+    {
+        NVTX_NULLPTR,
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCuDeviceA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCuDeviceW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCuContextA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCuContextW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCuStreamA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCuStreamW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCuEventA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCuEventW),
+        NVTX_NULLPTR
+    },
+    {
+        NVTX_NULLPTR,
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClDeviceA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClDeviceW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClContextA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClContextW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClCommandQueueA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClCommandQueueW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClMemObjectA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClMemObjectW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClSamplerA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClSamplerW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClProgramA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClProgramW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClEventA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameClEventW),
+        NVTX_NULLPTR
+    },
+    {
+        NVTX_NULLPTR,
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCudaDeviceA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCudaDeviceW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCudaStreamA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCudaStreamW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCudaEventA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxNameCudaEventW),
+        NVTX_NULLPTR
+    },
+    {
+        NVTX_NULLPTR,
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainMarkEx),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainRangeStartEx),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainRangeEnd),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainRangePushEx),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainRangePop),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainResourceCreate),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainResourceDestroy),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainNameCategoryA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainNameCategoryW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainRegisterStringA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainRegisterStringW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainCreateA),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainCreateW),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainDestroy),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxInitialize),
+        NVTX_NULLPTR
+    },
+    {
+        NVTX_NULLPTR,
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainSyncUserCreate),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainSyncUserDestroy),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainSyncUserAcquireStart),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainSyncUserAcquireFailed),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainSyncUserAcquireSuccess),
+        NVTX_GLOBAL_TABLE_ENTRY(nvtxDomainSyncUserReleasing),
+        NVTX_NULLPTR
+    }
+};
+
+#undef NVTX_GLOBAL_TABLE_ENTRY
+
+/* ---- Define static inline implementations of core API functions ---- */
+
+#include "nvtxImplCore.h"
+
+/* ---- Define implementations of export table functions ---- */
+
+NVTX_LINKONCE_DEFINE_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxEtiGetModuleFunctionTable)(
+    NvtxCallbackModule callback_module,
+    NvtxFunctionTable* out_table,
+    unsigned int* out_size)
+{
+    unsigned int bytes = 0;
+    NvtxFunctionTable table = NVTX_NULLPTR;
+
+    switch (callback_module)
+    {
+    case NVTX_CB_MODULE_CORE:
+        table = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CORE;
+        bytes = NVTX_STATIC_CAST(unsigned int, sizeof(NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CORE));
+        break;
+    case NVTX_CB_MODULE_CUDA:
+        table = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CUDA;
+        bytes = NVTX_STATIC_CAST(unsigned int, sizeof(NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CUDA));
+        break;
+    case NVTX_CB_MODULE_OPENCL:
+        table = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_OPENCL;
+        bytes = NVTX_STATIC_CAST(unsigned int, sizeof(NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_OPENCL));
+        break;
+    case NVTX_CB_MODULE_CUDART:
+        table = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CUDART;
+        bytes = NVTX_STATIC_CAST(unsigned int, sizeof(NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CUDART));
+        break;
+    case NVTX_CB_MODULE_CORE2:
+        table = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CORE2;
+        bytes = NVTX_STATIC_CAST(unsigned int, sizeof(NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CORE2));
+        break;
+    case NVTX_CB_MODULE_SYNC:
+        table = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_SYNC;
+        bytes = NVTX_STATIC_CAST(unsigned int, sizeof(NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_SYNC));
+        break;
+    case NVTX_CB_MODULE_INVALID:
+    case NVTX_CB_MODULE_SIZE:
+    case NVTX_CB_MODULE_FORCE_INT:
+    default: return 0;
+    }
+
+    if (out_size)
+        *out_size = (bytes / NVTX_STATIC_CAST(unsigned int, sizeof(NvtxFunctionPointer*))) - 1;
+
+    if (out_table)
+        *out_table = table;
+
+    return 1;
+}
+
+NVTX_LINKONCE_DEFINE_FUNCTION const void* NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxGetExportTable)(uint32_t exportTableId)
+{
+    switch (exportTableId)
+    {
+    case NVTX_ETID_CALLBACKS:       return &NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).etblCallbacks;
+    case NVTX_ETID_VERSIONINFO:     return &NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).etblVersionInfo;
+    default:                        return NVTX_NULLPTR;
+    }
+}
+
+NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxEtiSetInjectionNvtxVersion)(uint32_t version)
+{
+    /* Reserved for custom implementations to resolve problems with tools */
+    (void)version;
+}
+
+/* ---- Define implementations of init versions of all API functions ---- */
+
+#include "nvtxInitDefs.h"
+
+/* ---- Define implementations of initialization functions ---- */
+
+#include "nvtxInit.h"
+
+#ifdef __GNUC__
+#pragma GCC visibility pop
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxImplCore.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxImplCore.h
@@ -1,0 +1,432 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+NVTX_DECLSPEC void NVTX_API nvtxMarkEx(const nvtxEventAttributes_t* eventAttrib)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)eventAttrib;
+#else /* NVTX_DISABLE */
+    nvtxMarkEx_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxMarkEx_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(eventAttrib);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxMarkA(const char* message)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)message;
+#else /* NVTX_DISABLE */
+    nvtxMarkA_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxMarkA_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(message);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxMarkW(const wchar_t* message)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)message;
+#else /* NVTX_DISABLE */
+    nvtxMarkW_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxMarkW_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(message);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxRangeStartEx(const nvtxEventAttributes_t* eventAttrib)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)eventAttrib;
+#else /* NVTX_DISABLE */
+    nvtxRangeStartEx_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxRangeStartEx_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(eventAttrib);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(nvtxRangeId_t, 0);
+}
+
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxRangeStartA(const char* message)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)message;
+#else /* NVTX_DISABLE */
+    nvtxRangeStartA_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxRangeStartA_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(message);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(nvtxRangeId_t, 0);
+}
+
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxRangeStartW(const wchar_t* message)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)message;
+#else /* NVTX_DISABLE */
+    nvtxRangeStartW_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxRangeStartW_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(message);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(nvtxRangeId_t, 0);
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxRangeEnd(nvtxRangeId_t id)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)id;
+#else /* NVTX_DISABLE */
+    nvtxRangeEnd_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxRangeEnd_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(id);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC int NVTX_API nvtxRangePushEx(const nvtxEventAttributes_t* eventAttrib)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)eventAttrib;
+#else /* NVTX_DISABLE */
+    nvtxRangePushEx_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxRangePushEx_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(eventAttrib);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(int, NVTX_NO_PUSH_POP_TRACKING);
+}
+
+NVTX_DECLSPEC int NVTX_API nvtxRangePushA(const char* message)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)message;
+#else /* NVTX_DISABLE */
+    nvtxRangePushA_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxRangePushA_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(message);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(int, NVTX_NO_PUSH_POP_TRACKING);
+}
+
+NVTX_DECLSPEC int NVTX_API nvtxRangePushW(const wchar_t* message)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)message;
+#else /* NVTX_DISABLE */
+    nvtxRangePushW_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxRangePushW_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(message);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(int, NVTX_NO_PUSH_POP_TRACKING);
+}
+
+NVTX_DECLSPEC int NVTX_API nvtxRangePop(void)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifndef NVTX_DISABLE
+    nvtxRangePop_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxRangePop_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)();
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(int, NVTX_NO_PUSH_POP_TRACKING);
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxNameCategoryA(uint32_t category, const char* name)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)category;
+    (void)name;
+#else /* NVTX_DISABLE */
+    nvtxNameCategoryA_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxNameCategoryA_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(category, name);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxNameCategoryW(uint32_t category, const wchar_t* name)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)category;
+    (void)name;
+#else /* NVTX_DISABLE */
+    nvtxNameCategoryW_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxNameCategoryW_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(category, name);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxNameOsThreadA(uint32_t threadId, const char* name)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)threadId;
+    (void)name;
+#else /* NVTX_DISABLE */
+    nvtxNameOsThreadA_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxNameOsThreadA_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(threadId, name);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxNameOsThreadW(uint32_t threadId, const wchar_t* name)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)threadId;
+    (void)name;
+#else /* NVTX_DISABLE */
+    nvtxNameOsThreadW_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxNameOsThreadW_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(threadId, name);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxDomainMarkEx(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)eventAttrib;
+#else /* NVTX_DISABLE */
+    nvtxDomainMarkEx_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainMarkEx_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(domain, eventAttrib);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxDomainRangeStartEx(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)eventAttrib;
+#else /* NVTX_DISABLE */
+    nvtxDomainRangeStartEx_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainRangeStartEx_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(domain, eventAttrib);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(nvtxRangeId_t, 0);
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxDomainRangeEnd(nvtxDomainHandle_t domain, nvtxRangeId_t id)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)id;
+#else /* NVTX_DISABLE */
+    nvtxDomainRangeEnd_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainRangeEnd_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(domain, id);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC int NVTX_API nvtxDomainRangePushEx(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)eventAttrib;
+#else /* NVTX_DISABLE */
+    nvtxDomainRangePushEx_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainRangePushEx_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(domain, eventAttrib);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(int, NVTX_NO_PUSH_POP_TRACKING);
+}
+
+NVTX_DECLSPEC int NVTX_API nvtxDomainRangePop(nvtxDomainHandle_t domain)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+#else /* NVTX_DISABLE */
+    nvtxDomainRangePop_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainRangePop_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(domain);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_STATIC_CAST(int, NVTX_NO_PUSH_POP_TRACKING);
+}
+
+NVTX_DECLSPEC nvtxResourceHandle_t NVTX_API nvtxDomainResourceCreate(nvtxDomainHandle_t domain, nvtxResourceAttributes_t* attribs)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)attribs;
+#else /* NVTX_DISABLE */
+    nvtxDomainResourceCreate_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainResourceCreate_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(domain, attribs);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_NULLPTR;
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxDomainResourceDestroy(nvtxResourceHandle_t resource)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)resource;
+#else /* NVTX_DISABLE */
+    nvtxDomainResourceDestroy_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainResourceDestroy_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(resource);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxDomainNameCategoryA(nvtxDomainHandle_t domain, uint32_t category, const char* name)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)category;
+    (void)name;
+#else /* NVTX_DISABLE */
+    nvtxDomainNameCategoryA_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainNameCategoryA_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(domain, category, name);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxDomainNameCategoryW(nvtxDomainHandle_t domain, uint32_t category, const wchar_t* name)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)category;
+    (void)name;
+#else /* NVTX_DISABLE */
+    nvtxDomainNameCategoryW_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainNameCategoryW_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(domain, category, name);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC nvtxStringHandle_t NVTX_API nvtxDomainRegisterStringA(nvtxDomainHandle_t domain, const char* string)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)string;
+#else /* NVTX_DISABLE */
+    nvtxDomainRegisterStringA_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainRegisterStringA_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(domain, string);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_NULLPTR;
+}
+
+NVTX_DECLSPEC nvtxStringHandle_t NVTX_API nvtxDomainRegisterStringW(nvtxDomainHandle_t domain, const wchar_t* string)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+    (void)string;
+#else /* NVTX_DISABLE */
+    nvtxDomainRegisterStringW_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainRegisterStringW_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(domain, string);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_NULLPTR;
+}
+
+NVTX_DECLSPEC nvtxDomainHandle_t NVTX_API nvtxDomainCreateA(const char* message)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)message;
+#else /* NVTX_DISABLE */
+    nvtxDomainCreateA_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainCreateA_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(message);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_NULLPTR;
+}
+
+NVTX_DECLSPEC nvtxDomainHandle_t NVTX_API nvtxDomainCreateW(const wchar_t* message)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)message;
+#else /* NVTX_DISABLE */
+    nvtxDomainCreateW_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainCreateW_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        return (*local)(message);
+    else
+#endif /* NVTX_DISABLE */
+        return NVTX_NULLPTR;
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxDomainDestroy(nvtxDomainHandle_t domain)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)domain;
+#else /* NVTX_DISABLE */
+    nvtxDomainDestroy_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxDomainDestroy_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(domain);
+#endif /* NVTX_DISABLE */
+}
+
+NVTX_DECLSPEC void NVTX_API nvtxInitialize(const void* reserved)
+{
+    NVTX_SET_NAME_MANGLING_OPTIONS
+#ifdef NVTX_DISABLE
+    (void)reserved;
+#else /* NVTX_DISABLE */
+    nvtxInitialize_impl_fntype local = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).nvtxInitialize_impl_fnptr;
+    if (local != NVTX_NULLPTR)
+        (*local)(reserved);
+#endif /* NVTX_DISABLE */
+}

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxInit.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxInit.h
@@ -1,0 +1,468 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#ifndef NVTX_IMPL_GUARD
+#error Never include this file directly -- it is automatically included by nvToolsExt.h (except when NVTX_NO_IMPL is defined).
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+/* ---- Platform-independent helper definitions and functions ---- */
+
+/* Prefer macros over inline functions to reduce symbol resolution at link time */
+
+#if defined(_WIN32)
+#define NVTX_PATHCHAR   wchar_t
+#define NVTX_STR(x)     L##x
+#define NVTX_GETENV     _wgetenv
+#define NVTX_BUFSIZE    16384
+#define NVTX_DLLHANDLE  HMODULE
+#define NVTX_DLLOPEN(x) LoadLibraryW(x)
+#define NVTX_DLLFUNC(h, x) NVTX_REINTERPRET_CAST(void(*)(void), GetProcAddress((h), (x)))
+#define NVTX_DLLCLOSE   FreeLibrary
+#define NVTX_DLLDEFAULT NVTX_NULLPTR
+#define NVTX_YIELD()    SwitchToThread()
+#define NVTX_MEMBAR()   MemoryBarrier()
+#define NVTX_ATOMIC_WRITE_32(address, value) \
+    InterlockedExchange(NVTX_REINTERPRET_CAST(volatile LONG*, (address)), (value))
+#define NVTX_ATOMIC_CAS_32(old, address, exchange, comparand) \
+    (old) = InterlockedCompareExchange(NVTX_REINTERPRET_CAST(volatile LONG*, (address)), (exchange), (comparand))
+#elif defined(__GNUC__)
+#define NVTX_PATHCHAR   char
+#define NVTX_STR(x)     x
+#define NVTX_GETENV     getenv
+#define NVTX_BUFSIZE    16384
+#define NVTX_DLLHANDLE  void*
+#define NVTX_DLLOPEN(x) dlopen(x, RTLD_LAZY)
+#define NVTX_DLLFUNC(h, x) dlsym((h), (x))
+#define NVTX_DLLCLOSE   dlclose
+#if !defined(__APPLE__)
+#define NVTX_DLLDEFAULT NVTX_NULLPTR
+#else
+#define NVTX_DLLDEFAULT RTLD_DEFAULT
+#endif
+#define NVTX_YIELD()    sched_yield()
+#define NVTX_MEMBAR()   __sync_synchronize()
+/* Ensure full memory barrier for atomics, to match Windows functions */
+#define NVTX_ATOMIC_WRITE_32(address, value) \
+    __sync_synchronize(); *(address) = (value); __sync_synchronize()
+#define NVTX_ATOMIC_CAS_32(old, address, exchange, comparand) \
+    (old) = __sync_val_compare_and_swap((address), (comparand), (exchange))
+#else
+#error The library does not support your configuration!
+#endif
+
+/* NVTX_LOAD_SEQUENCE_VERSION macro
+*
+*  NVTX3 can update the search sequence used for finding a suitable injection library.
+*  If multiple copies of the NVTX3 headers are included in the same translation unit,
+*  the one included first sets the loader sequence.  If there is any problem where a
+*  tool is expected to load, but is not loading, the app can test this macro to verify
+*  which version of the search is being used.  Check if NVTX_LOAD_SEQUENCE_VERSION is
+*  defined; if it is not, the version is 1.  Otherwise, the version is indicated by
+*  the value of NVTX_LOAD_SEQUENCE_VERSION.
+*
+*  Version history:
+*    1: NVTX3 initial implementation.  The search continues until a usable function
+*       pointer is found.  If none is found, init aborts and rolls back anything it
+*       did during the search (e.g. any loaded libraries are unloaded).  If a non-zero
+*       function pointer is found, it is called.  If that function returns non-zero
+*       ("true" in C), that indicates a tool successfully initialized.  If it returns
+*       zero ("false"), the tool init was unsuccessful, so init aborts and rolls back
+*       anything it did.  No further attempt is made to search for a different init
+*       function if the first one found returns false.  The search order is:
+*       - Check for env var NVTX_INJECTION64_PATH (or "32" in 32-bit process)
+*         - Treat env var value as path to dynamic library, try loading it
+*         - If it loads, try get the exported symbol "InitializeInjectionNvtx2"
+*         - If this returns a non-null pointer, the search finishes here
+*       - (Android only) Look for libNvtxInjection64.so (or "32" in 32-bit process)
+*         - Must be in the /data/data/<package name>/files" directory
+*         - Treat env var value as path to dynamic library, try loading it
+*         - If it loads, try get the exported symbol "InitializeInjectionNvtx2"
+*         - If this returns a non-null pointer, the search finishes here
+*       Note: There were two other options partially implemented, but disabled.
+*       - For supporting a pre-injected library on POSIX platforms, e.g. with
+*         LD_PRELOAD, try using dlsym with a null module handle to get the init
+*         function.  This was unconditionally disabled after finding cases where
+*         a tool loaded multiple injections that supported NVTX, and couldn't
+*         control which one was getting picked by the NVTX loader.
+*       - (Linux only, not including Cygwin) Check for static injection using a
+*         weak symbol.  This was implemented incorrectly, so it wasn't usable.
+*
+*    2: Fix the support for static injection libraries.  This is meant for cases
+*       where dlopen is not supported or allowed, and the executable format has
+*       support for weak symbols.  Tools may provide a static library with a
+*       C-linkage symbol named "InitializeInjectionNvtx2_fnptr", whose type is
+*       NvtxInitializeInjectionNvtxFunc_t, i.e. a function pointer to NVTX init
+*       function.  If such a symbol is provided by a static library, the NVTX
+*       loader's weak symbol will bind to it and call it for initialization.
+*       Otherwise, the weak symbol will be defined by NVTX and default to null,
+*       indicating no static injection library is present.  Static injection is
+*       last in the load sequence, because it gives all the run-time methods of
+*       injection to override a program's compiled-in tool without rebuilding the
+*       program.  The search order is:
+*       - Check for env var NVTX_INJECTION64_PATH (or "32" in 32-bit process)
+*         - Treat env var value as path to dynamic library, try loading it
+*         - If it loads, try get the exported symbol "InitializeInjectionNvtx2"
+*         - If this returns a non-null pointer, the search finishes here
+*       - (Android only) Look for libNvtxInjection64.so (or "32" in 32-bit process)
+*         - Must be in the /data/data/<package name>/files" directory
+*         - Treat env var value as path to dynamic library, try loading it
+*         - If it loads, try get the exported symbol "InitializeInjectionNvtx2"
+*         - If this returns a non-null pointer, the search finishes here
+*       - (Currently disabled, experimental support for non-Windows) Use dlsym
+*         with a null module handle to query the process-wide dynamic symbol
+*         table for a function named "InitializeInjectionNvtx2Preinject".  The
+*         symbol is different to prevent injections from being loaded this way
+*         unless they choose to do so.
+*         - If this returns a non-null pointer, the search finishes here
+*       - (GCC-like compilers with ELF binary targets only) Check for static
+*         injection using a weak symbol "InitializeInjectionNvtx2_fnptr".
+*       If the default support choices in this header are not working as expected,
+*       clients may now override load sequence support decisions by defining these
+*       macros before including the NVTX header files:
+*       - NVTX_SUPPORT_ENV_VARS
+*       - NVTX_SUPPORT_DYNAMIC_INJECTION_LIBRARY
+*       - NVTX_SUPPORT_ANDROID_INJECTION_LIBRARY_IN_PACKAGE
+*       - NVTX_SUPPORT_ALREADY_INJECTED_LIBRARY
+*       - NVTX_SUPPORT_STATIC_INJECTION_LIBRARY
+*/
+#define NVTX_LOAD_SEQUENCE_VERSION 2
+
+#ifndef NVTX_SUPPORT_ALREADY_INJECTED_LIBRARY
+/* Define this to 1 for platforms that where pre-injected libraries can be discovered. */
+#if defined(_WIN32)
+/* Windows has no process-wide table of dynamic library symbols, so this can't be supported. */
+#define NVTX_SUPPORT_ALREADY_INJECTED_LIBRARY 0
+#else
+/* POSIX platforms allow calling dlsym on a null module to use the process-wide table.
+*  Note: Still disabled in load sequence version 2.  Needs to support following the
+*  RTLD_NEXT chain, and needs more testing before support can be enabled by default.*/
+#define NVTX_SUPPORT_ALREADY_INJECTED_LIBRARY 0
+#endif
+#endif
+
+#ifndef NVTX_SUPPORT_ENV_VARS
+/* Define this to 1 for platforms that support environment variables */
+/* TODO: Detect UWP, a.k.a. Windows Store app, and set this to 0. */
+/* Try:  #if defined(WINAPI_FAMILY_PARTITION) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) */
+#define NVTX_SUPPORT_ENV_VARS 1
+#endif
+
+#ifndef NVTX_SUPPORT_DYNAMIC_INJECTION_LIBRARY
+/* Define this to 1 for platforms that support dynamic/shared libraries */
+#define NVTX_SUPPORT_DYNAMIC_INJECTION_LIBRARY 1
+#endif
+
+#ifndef NVTX_SUPPORT_ANDROID_INJECTION_LIBRARY_IN_PACKAGE
+#if defined(__ANDROID__)
+#define NVTX_SUPPORT_ANDROID_INJECTION_LIBRARY_IN_PACKAGE 1
+#else
+#define NVTX_SUPPORT_ANDROID_INJECTION_LIBRARY_IN_PACKAGE 0
+#endif
+#endif
+
+#ifndef NVTX_SUPPORT_STATIC_INJECTION_LIBRARY
+/* On platforms that support weak symbols (i.e. non-Windows), injection libraries may
+*  be statically linked into an application.  This is useful for platforms where dynamic
+*  injection is not available.  Weak symbols not marked extern are definitions, not just
+*  declarations.  They are guaranteed to be initialized to zero if no normal definitions
+*  are found by the linker to override them.  This means the NVTX load sequence can safely
+*  detect the presence of a static injection -- if InitializeInjectionNvtx2_fnptr is zero,
+*  there is no static injection. */
+#if defined(__GNUC__) && !defined(_WIN32) && !defined(__CYGWIN__)
+#define NVTX_SUPPORT_STATIC_INJECTION_LIBRARY 1
+#else
+#define NVTX_SUPPORT_STATIC_INJECTION_LIBRARY 0
+#endif
+#endif
+
+#if NVTX_SUPPORT_STATIC_INJECTION_LIBRARY && !defined(NVTX_STATIC_INJECTION_IMPL)
+/* To make an NVTX injection library support static injection, it must do these things:
+*  - Define InitializeInjectionNvtx2_fnptr as a normal symbol (not weak), pointing to
+*    the implementation of InitializeInjectionNvtx2 (which does not need to be a
+*    dynamic export if only supporting static injection).
+*  - Define NVTX_STATIC_INJECTION_IMPL so the weak definition below is skipped.
+*  - Compile the static injection files with -fPIC if they are to be linked with other
+*    files compiled this way.  If you forget this, GCC will simply tell you to add it.
+*  When building the application, there a few ways to link in a static injection:
+*  - Compile the injection's source files normally, and include the .o files as inputs
+*    to the linker.
+*  - If the injection is provided as an archive (.a file), it will not resolve any
+*    unresolved symbols, so the linker will skip it by default.  This can be fixed
+*    by wrapping the static injection's name on the linker command line with options
+*    to treat it differently.  For example:
+*      gcc example.o libfoo.a -Wl,--whole-archive libinj-static.a -Wl,--no-whole-archive libbar.a
+*    Note that libinj-static.a is bracketed by options to turn on "whole archive" and
+*    then back off again afterwards, so libfoo.a and libbar.a are linked normally.
+*  - In CMake, a static injection can be added with options like this:
+*      target_link_libraries(app PRIVATE -Wl,--whole-archive inj-static -Wl,--no-whole-archive)
+*/
+__attribute__((weak)) NvtxInitializeInjectionNvtxFunc_t InitializeInjectionNvtx2_fnptr;
+#endif
+
+/* This function tries to find or load an NVTX injection library and get the
+*  address of its InitializeInjection2 function.  If such a function pointer
+*  is found, it is called, and passed the address of this NVTX instance's
+*  nvtxGetExportTable function, so the injection can attach to this instance.
+*  If the initialization fails for any reason, any dynamic library loaded will
+*  be freed, and all NVTX implementation functions will be set to no-ops.  If
+*  initialization succeeds, NVTX functions not attached to the tool will be set
+*  to no-ops.  This is implemented as one function instead of several small
+*  functions to minimize the number of weak symbols the linker must resolve.
+*  Order of search is:
+*  - Pre-injected library exporting InitializeInjectionNvtx2
+*  - Loadable library exporting InitializeInjectionNvtx2
+*      - Path specified by env var NVTX_INJECTION??_PATH (?? is 32 or 64)
+*      - On Android, libNvtxInjection??.so within the package (?? is 32 or 64)
+*  - Statically-linked injection library defining InitializeInjectionNvtx2_fnptr
+*/
+NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_VERSIONED_IDENTIFIER(nvtxInitializeInjectionLibrary)(void);
+NVTX_LINKONCE_DEFINE_FUNCTION int NVTX_VERSIONED_IDENTIFIER(nvtxInitializeInjectionLibrary)(void)
+{
+    static const char initFuncName[] = "InitializeInjectionNvtx2";
+#if NVTX_SUPPORT_ALREADY_INJECTED_LIBRARY
+    static const char initFuncPreinjectName[] = "InitializeInjectionNvtx2Preinject";
+#endif
+    NvtxInitializeInjectionNvtxFunc_t init_fnptr = NVTX_NULLPTR;
+    NVTX_DLLHANDLE injectionLibraryHandle = NVTX_DLLDEFAULT;
+    int entryPointStatus = 0;
+
+#if NVTX_SUPPORT_DYNAMIC_INJECTION_LIBRARY
+    /* Try discovering dynamic injection library to load */
+    {
+#if NVTX_SUPPORT_ENV_VARS
+        /* If env var NVTX_INJECTION64_PATH is set, it should contain the path
+        *  to a 64-bit dynamic NVTX injection library (and similar for 32-bit). */
+        const NVTX_PATHCHAR* const nvtxEnvVarName = (sizeof(void*) == 4)
+            ? NVTX_STR("NVTX_INJECTION32_PATH")
+            : NVTX_STR("NVTX_INJECTION64_PATH");
+#endif /* NVTX_SUPPORT_ENV_VARS */
+        NVTX_PATHCHAR injectionLibraryPathBuf[NVTX_BUFSIZE];
+        const NVTX_PATHCHAR* injectionLibraryPath = NVTX_NULLPTR;
+
+        /* Refer to this variable explicitly in case all references to it are #if'ed out */
+        (void)injectionLibraryPathBuf;
+
+#if NVTX_SUPPORT_ENV_VARS
+        /* Disable the warning for getenv & _wgetenv -- this usage is safe because
+        *  these functions are not called again before using the returned value. */
+#if defined(_MSC_VER)
+#pragma warning( push )
+#pragma warning( disable : 4996 )
+#endif
+        injectionLibraryPath = NVTX_GETENV(nvtxEnvVarName);
+#if defined(_MSC_VER)
+#pragma warning( pop )
+#endif
+#endif
+
+#if NVTX_SUPPORT_ANDROID_INJECTION_LIBRARY_IN_PACKAGE
+        if (!injectionLibraryPath)
+        {
+            const char *bits = (sizeof(void*) == 4) ? "32" : "64";
+            char cmdlineBuf[32];
+            char pkgName[PATH_MAX];
+            int count;
+            int pid;
+            FILE *fp;
+            size_t bytesRead;
+            size_t pos;
+
+            pid = NVTX_STATIC_CAST(int, getpid());
+            count = snprintf(cmdlineBuf, sizeof(cmdlineBuf), "/proc/%d/cmdline", pid);
+            if (count <= 0 || count >= NVTX_STATIC_CAST(int, sizeof(cmdlineBuf)))
+            {
+                NVTX_ERR("Path buffer too small for: /proc/%d/cmdline\n", pid);
+                return NVTX_ERR_INIT_ACCESS_LIBRARY;
+            }
+
+            fp = fopen(cmdlineBuf, "r");
+            if (!fp)
+            {
+                NVTX_ERR("File couldn't be opened: %s\n", cmdlineBuf);
+                return NVTX_ERR_INIT_ACCESS_LIBRARY;
+            }
+
+            bytesRead = fread(pkgName, 1, sizeof(pkgName) - 1, fp);
+            fclose(fp);
+            if (bytesRead == 0)
+            {
+                NVTX_ERR("Package name couldn't be read from file: %s\n", cmdlineBuf);
+                return NVTX_ERR_INIT_ACCESS_LIBRARY;
+            }
+
+            pkgName[bytesRead] = 0;
+
+            /* String can contain colon as a process separator. In this case the package name is before the colon. */
+            pos = 0;
+            while (pos < bytesRead && pkgName[pos] != ':' && pkgName[pos] != '\0')
+            {
+                ++pos;
+            }
+            pkgName[pos] = 0;
+
+            count = snprintf(injectionLibraryPathBuf, NVTX_BUFSIZE, "/data/data/%s/files/libNvtxInjection%s.so", pkgName, bits);
+            if (count <= 0 || count >= NVTX_BUFSIZE)
+            {
+                NVTX_ERR("Path buffer too small for: /data/data/%s/files/libNvtxInjection%s.so\n", pkgName, bits);
+                return NVTX_ERR_INIT_ACCESS_LIBRARY;
+            }
+
+            /* On Android, verify path is accessible due to aggressive file access restrictions. */
+            /* For dlopen, if the filename contains a leading slash, then it is interpreted as a */
+            /* relative or absolute pathname; otherwise it will follow the rules in ld.so. */
+            if (injectionLibraryPathBuf[0] == '/')
+            {
+#if (__ANDROID_API__ < 21)
+                int access_err = access(injectionLibraryPathBuf, F_OK | R_OK);
+#else
+                int access_err = faccessat(AT_FDCWD, injectionLibraryPathBuf, F_OK | R_OK, 0);
+#endif
+                if (access_err != 0)
+                {
+                    NVTX_ERR("Injection library path wasn't accessible [code=%s] [path=%s]\n", strerror(errno), injectionLibraryPathBuf);
+                    return NVTX_ERR_INIT_ACCESS_LIBRARY;
+                }
+            }
+            injectionLibraryPath = injectionLibraryPathBuf;
+        }
+#endif /* NVTX_SUPPORT_ANDROID_INJECTION_LIBRARY_IN_PACKAGE */
+
+        /* At this point, injectionLibraryPath is specified if a dynamic
+        *  injection library was specified by a tool. */
+        if (injectionLibraryPath)
+        {
+            /* Load the injection library */
+            injectionLibraryHandle = NVTX_DLLOPEN(injectionLibraryPath);
+            if (!injectionLibraryHandle)
+            {
+                NVTX_ERR("Failed to load injection library\n");
+                return NVTX_ERR_INIT_LOAD_LIBRARY;
+            }
+            else
+            {
+                /* Attempt to get the injection library's entry-point */
+                init_fnptr = NVTX_REINTERPRET_CAST(NvtxInitializeInjectionNvtxFunc_t, NVTX_DLLFUNC(injectionLibraryHandle, initFuncName));
+                if (!init_fnptr)
+                {
+                    NVTX_DLLCLOSE(injectionLibraryHandle);
+                    NVTX_ERR("Failed to get address of function InitializeInjectionNvtx2 from injection library\n");
+                    return NVTX_ERR_INIT_MISSING_LIBRARY_ENTRY_POINT;
+                }
+            }
+        }
+    }
+#endif /* NVTX_SUPPORT_DYNAMIC_INJECTION_LIBRARY */
+
+#if NVTX_SUPPORT_ALREADY_INJECTED_LIBRARY
+    if (!init_fnptr)
+    {
+        /* Use POSIX global symbol chain to query for init function from any module */
+        init_fnptr = NVTX_REINTERPRET_CAST(NvtxInitializeInjectionNvtxFunc_t, NVTX_DLLFUNC(NVTX_DLLDEFAULT, initFuncPreinjectName));
+    }
+#endif
+
+#if NVTX_SUPPORT_STATIC_INJECTION_LIBRARY
+    if (!init_fnptr)
+    {
+        /* Check weakly-defined function pointer.  A statically-linked injection can define this
+        *  as a normal symbol and set it to the address of the NVTX init function -- this will
+        *  provide a non-null value here.  If there is no other definition of this symbol, it
+        *  will be null here. */
+        if (InitializeInjectionNvtx2_fnptr)
+        {
+            init_fnptr = InitializeInjectionNvtx2_fnptr;
+        }
+    }
+#endif
+
+    /* At this point, if init_fnptr is not set, then no tool has specified
+    *  an NVTX injection library -- return non-success result so all NVTX
+    *  API functions will be set to no-ops. */
+    if (!init_fnptr)
+    {
+        return NVTX_ERR_NO_INJECTION_LIBRARY_AVAILABLE;
+    }
+
+    /* Invoke injection library's initialization function.  If it returns
+    *  0 (failure) and a dynamic injection was loaded, unload it. */
+    entryPointStatus = init_fnptr(NVTX_VERSIONED_IDENTIFIER(nvtxGetExportTable));
+    if (entryPointStatus == 0)
+    {
+        NVTX_ERR("Failed to initialize injection library -- initialization function returned 0\n");
+        if (injectionLibraryHandle)
+        {
+            NVTX_DLLCLOSE(injectionLibraryHandle);
+        }
+        return NVTX_ERR_INIT_FAILED_LIBRARY_ENTRY_POINT;
+    }
+
+    return NVTX_SUCCESS;
+}
+
+NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_VERSIONED_IDENTIFIER(nvtxInitOnce)(void)
+{
+    unsigned int old;
+    if (NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).initState == NVTX_INIT_STATE_COMPLETE)
+    {
+        return;
+    }
+
+    NVTX_ATOMIC_CAS_32(
+        old,
+        &NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).initState,
+        NVTX_INIT_STATE_STARTED,
+        NVTX_INIT_STATE_FRESH);
+    if (old == NVTX_INIT_STATE_FRESH)
+    {
+        int result;
+        int forceAllToNoops;
+
+        /* Load & initialize injection library -- it will assign the function pointers */
+        result = NVTX_VERSIONED_IDENTIFIER(nvtxInitializeInjectionLibrary)();
+
+        /* Set all pointers not assigned by the injection to null */
+        forceAllToNoops = result != NVTX_SUCCESS; /* Set all to null if injection init failed */
+        NVTX_VERSIONED_IDENTIFIER(nvtxSetInitFunctionsToNoops)(forceAllToNoops);
+
+        /* Signal that initialization has finished, so now the assigned function pointers will be used */
+        NVTX_ATOMIC_WRITE_32(
+            &NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).initState,
+            NVTX_INIT_STATE_COMPLETE);
+    }
+    else /* Spin-wait until initialization has finished */
+    {
+        NVTX_MEMBAR();
+        while (NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).initState != NVTX_INIT_STATE_COMPLETE)
+        {
+            NVTX_YIELD();
+            NVTX_MEMBAR();
+        }
+    }
+}

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxInitDecls.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxInitDecls.h
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#ifndef NVTX_IMPL_GUARD
+#error Never include this file directly -- it is automatically included by nvToolsExt.h (except when NVTX_NO_IMPL is defined).
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxMarkEx_impl_init)(const nvtxEventAttributes_t* eventAttrib);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxMarkA_impl_init)(const char* message);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxMarkW_impl_init)(const wchar_t* message);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxRangeId_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxRangeStartEx_impl_init)(const nvtxEventAttributes_t* eventAttrib);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxRangeId_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxRangeStartA_impl_init)(const char* message);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxRangeId_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxRangeStartW_impl_init)(const wchar_t* message);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxRangeEnd_impl_init)(nvtxRangeId_t id);
+NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxRangePushEx_impl_init)(const nvtxEventAttributes_t* eventAttrib);
+NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxRangePushA_impl_init)(const char* message);
+NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxRangePushW_impl_init)(const wchar_t* message);
+NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxRangePop_impl_init)(void);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCategoryA_impl_init)(uint32_t category, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCategoryW_impl_init)(uint32_t category, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameOsThreadA_impl_init)(uint32_t threadId, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameOsThreadW_impl_init)(uint32_t threadId, const wchar_t* name);
+
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCuDeviceA_impl_init)(nvtx_CUdevice device, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCuDeviceW_impl_init)(nvtx_CUdevice device, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCuContextA_impl_init)(nvtx_CUcontext context, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCuContextW_impl_init)(nvtx_CUcontext context, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCuStreamA_impl_init)(nvtx_CUstream stream, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCuStreamW_impl_init)(nvtx_CUstream stream, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCuEventA_impl_init)(nvtx_CUevent event, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCuEventW_impl_init)(nvtx_CUevent event, const wchar_t* name);
+
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClDeviceA_impl_init)(nvtx_cl_device_id device, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClDeviceW_impl_init)(nvtx_cl_device_id device, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClContextA_impl_init)(nvtx_cl_context context, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClContextW_impl_init)(nvtx_cl_context context, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClCommandQueueA_impl_init)(nvtx_cl_command_queue command_queue, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClCommandQueueW_impl_init)(nvtx_cl_command_queue command_queue, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClMemObjectA_impl_init)(nvtx_cl_mem memobj, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClMemObjectW_impl_init)(nvtx_cl_mem memobj, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClSamplerA_impl_init)(nvtx_cl_sampler sampler, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClSamplerW_impl_init)(nvtx_cl_sampler sampler, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClProgramA_impl_init)(nvtx_cl_program program, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClProgramW_impl_init)(nvtx_cl_program program, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClEventA_impl_init)(nvtx_cl_event evnt, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameClEventW_impl_init)(nvtx_cl_event evnt, const wchar_t* name);
+
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaDeviceA_impl_init)(int device, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaDeviceW_impl_init)(int device, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaStreamA_impl_init)(nvtx_cudaStream_t stream, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaStreamW_impl_init)(nvtx_cudaStream_t stream, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaEventA_impl_init)(nvtx_cudaEvent_t event, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxNameCudaEventW_impl_init)(nvtx_cudaEvent_t event, const wchar_t* name);
+
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainMarkEx_impl_init)(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxRangeId_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainRangeStartEx_impl_init)(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainRangeEnd_impl_init)(nvtxDomainHandle_t domain, nvtxRangeId_t id);
+NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainRangePushEx_impl_init)(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainRangePop_impl_init)(nvtxDomainHandle_t domain);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxResourceHandle_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainResourceCreate_impl_init)(nvtxDomainHandle_t domain, nvtxResourceAttributes_t* attribs);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainResourceDestroy_impl_init)(nvtxResourceHandle_t resource);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainNameCategoryA_impl_init)(nvtxDomainHandle_t domain, uint32_t category, const char* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainNameCategoryW_impl_init)(nvtxDomainHandle_t domain, uint32_t category, const wchar_t* name);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxStringHandle_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainRegisterStringA_impl_init)(nvtxDomainHandle_t domain, const char* string);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxStringHandle_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainRegisterStringW_impl_init)(nvtxDomainHandle_t domain, const wchar_t* string);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxDomainHandle_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainCreateA_impl_init)(const char* message);
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtxDomainHandle_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainCreateW_impl_init)(const wchar_t* message);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainDestroy_impl_init)(nvtxDomainHandle_t domain);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxInitialize_impl_init)(const void* reserved);
+
+NVTX_LINKONCE_FWDDECL_FUNCTION nvtx_nvtxSyncUser_t NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserCreate_impl_init)(nvtxDomainHandle_t domain, const nvtx_nvtxSyncUserAttributes_t* attribs);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserDestroy_impl_init)(nvtx_nvtxSyncUser_t handle);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserAcquireStart_impl_init)(nvtx_nvtxSyncUser_t handle);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserAcquireFailed_impl_init)(nvtx_nvtxSyncUser_t handle);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserAcquireSuccess_impl_init)(nvtx_nvtxSyncUser_t handle);
+NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxDomainSyncUserReleasing_impl_init)(nvtx_nvtxSyncUser_t handle);

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxLinkOnce.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxLinkOnce.h
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+#ifndef __NVTX_LINKONCE_H__
+#define __NVTX_LINKONCE_H__
+
+/* This header defines macros to permit making definitions of global variables
+ * and functions in C/C++ header files which may be included multiple times in
+ * a translation unit or linkage unit.  It allows authoring header-only libraries
+ * which can be used by multiple other header-only libraries (either as the same
+ * copy or multiple copies), and does not require any build changes, such as
+ * adding another .c file, linking a static library, or deploying a dynamic
+ * library.  Globals defined with these macros have the property that they have
+ * the same address, pointing to a single instance, for the entire linkage unit.
+ * It is expected but not guaranteed that each linkage unit will have a separate
+ * instance.
+ *
+ * In some situations it is desirable to declare a variable without initializing
+ * it, refer to it in code or other variables' initializers, and then initialize
+ * it later.  Similarly, functions can be prototyped, have their address taken,
+ * and then have their body defined later.  In such cases, use the FWDDECL macros
+ * when forward-declaring LINKONCE global variables without initializers and
+ * function prototypes, and then use the DEFINE macros when later defining them.
+ * Although in many cases the FWDDECL macro is equivalent to the DEFINE macro,
+ * following this pattern makes code maximally portable.
+ */
+
+#if defined(_MSC_VER) /* MSVC */
+    #if defined(__cplusplus)
+        #define NVTX_LINKONCE_DEFINE_GLOBAL   extern "C" __declspec(selectany)
+        #define NVTX_LINKONCE_DEFINE_FUNCTION extern "C" inline
+    #else
+        #define NVTX_LINKONCE_DEFINE_GLOBAL   __declspec(selectany)
+        #define NVTX_LINKONCE_DEFINE_FUNCTION __inline
+    #endif
+    #define NVTX_LINKONCE_FWDDECL_GLOBAL      NVTX_LINKONCE_DEFINE_GLOBAL extern
+#elif defined(_WIN32) || defined(__CYGWIN__) /* MinGW */
+    #if defined(__cplusplus)
+        #define NVTX_LINKONCE_DEFINE_GLOBAL   __declspec(selectany)
+        #define NVTX_LINKONCE_DEFINE_FUNCTION extern "C" inline
+    #else
+        #define NVTX_LINKONCE_DEFINE_GLOBAL   __declspec(selectany)
+        #define NVTX_LINKONCE_DEFINE_FUNCTION
+    #endif
+    #define NVTX_LINKONCE_FWDDECL_GLOBAL      extern
+#else /* All others: Assume GCC, clang, or compatible */
+    #define NVTX_LINKONCE_WEAK   __attribute__((weak))
+    #define NVTX_LINKONCE_HIDDEN __attribute__((visibility("hidden")))
+    #if defined(__cplusplus)
+        #define NVTX_LINKONCE_DEFINE_GLOBAL   NVTX_LINKONCE_HIDDEN NVTX_LINKONCE_WEAK
+        #define NVTX_LINKONCE_DEFINE_FUNCTION extern "C" NVTX_LINKONCE_HIDDEN inline
+    #else
+        #define NVTX_LINKONCE_DEFINE_GLOBAL   NVTX_LINKONCE_HIDDEN NVTX_LINKONCE_WEAK
+        #define NVTX_LINKONCE_DEFINE_FUNCTION NVTX_LINKONCE_HIDDEN NVTX_LINKONCE_WEAK
+    #endif
+    #define NVTX_LINKONCE_FWDDECL_GLOBAL      NVTX_LINKONCE_DEFINE_GLOBAL extern
+#endif
+
+#define NVTX_LINKONCE_FWDDECL_FUNCTION        NVTX_LINKONCE_DEFINE_FUNCTION
+
+#endif /* __NVTX_LINKONCE_H__ */

--- a/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxTypes.h
+++ b/third_party/nvtx/include/nvtx3/nvtxDetail/nvtxTypes.h
@@ -1,0 +1,318 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Licensed under the Apache License v2.0 with LLVM Exceptions.
+ * See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+ */
+
+/* This header defines types which are used by the internal implementation
+*  of NVTX and callback subscribers.  API clients do not use these types,
+*  so they are defined here instead of in nvToolsExt.h to clarify they are
+*  not part of the NVTX client API. */
+
+#ifndef NVTX_IMPL_GUARD
+#error Never include this file directly -- it is automatically included by nvToolsExt.h.
+#endif
+
+#if defined(NVTX_AS_SYSTEM_HEADER)
+#if defined(__clang__)
+#pragma clang system_header
+#elif defined(__GNUC__) || defined(__NVCOMPILER)
+#pragma GCC system_header
+#elif defined(_MSC_VER)
+#pragma system_header
+#endif
+#endif
+
+/* ------ Dependency-free types binary-compatible with real types ------- */
+
+/* In order to avoid having the NVTX core API headers depend on non-NVTX
+*  headers like cuda.h, NVTX defines binary-compatible types to use for
+*  safely making the initialization versions of all NVTX functions without
+*  needing to have definitions for the real types. */
+
+typedef int   nvtx_CUdevice;
+typedef void* nvtx_CUcontext;
+typedef void* nvtx_CUstream;
+typedef void* nvtx_CUevent;
+
+typedef void* nvtx_cudaStream_t;
+typedef void* nvtx_cudaEvent_t;
+
+typedef void* nvtx_cl_platform_id;
+typedef void* nvtx_cl_device_id;
+typedef void* nvtx_cl_context;
+typedef void* nvtx_cl_command_queue;
+typedef void* nvtx_cl_mem;
+typedef void* nvtx_cl_program;
+typedef void* nvtx_cl_kernel;
+typedef void* nvtx_cl_event;
+typedef void* nvtx_cl_sampler;
+
+typedef void* nvtx_nvtxSyncUser_t;
+typedef void nvtx_nvtxSyncUserAttributes_t;
+
+/* --------- Types for function pointers (with fake API types) ---------- */
+
+typedef void (NVTX_API * nvtxMarkEx_impl_fntype)(const nvtxEventAttributes_t* eventAttrib);
+typedef void (NVTX_API * nvtxMarkA_impl_fntype)(const char* message);
+typedef void (NVTX_API * nvtxMarkW_impl_fntype)(const wchar_t* message);
+typedef nvtxRangeId_t (NVTX_API * nvtxRangeStartEx_impl_fntype)(const nvtxEventAttributes_t* eventAttrib);
+typedef nvtxRangeId_t (NVTX_API * nvtxRangeStartA_impl_fntype)(const char* message);
+typedef nvtxRangeId_t (NVTX_API * nvtxRangeStartW_impl_fntype)(const wchar_t* message);
+typedef void (NVTX_API * nvtxRangeEnd_impl_fntype)(nvtxRangeId_t id);
+typedef int (NVTX_API * nvtxRangePushEx_impl_fntype)(const nvtxEventAttributes_t* eventAttrib);
+typedef int (NVTX_API * nvtxRangePushA_impl_fntype)(const char* message);
+typedef int (NVTX_API * nvtxRangePushW_impl_fntype)(const wchar_t* message);
+typedef int (NVTX_API * nvtxRangePop_impl_fntype)(void);
+typedef void (NVTX_API * nvtxNameCategoryA_impl_fntype)(uint32_t category, const char* name);
+typedef void (NVTX_API * nvtxNameCategoryW_impl_fntype)(uint32_t category, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameOsThreadA_impl_fntype)(uint32_t threadId, const char* name);
+typedef void (NVTX_API * nvtxNameOsThreadW_impl_fntype)(uint32_t threadId, const wchar_t* name);
+
+/* Real impl types are defined in nvtxImplCuda_v3.h, where CUDA headers are included */
+typedef void (NVTX_API * nvtxNameCuDeviceA_fakeimpl_fntype)(nvtx_CUdevice device, const char* name);
+typedef void (NVTX_API * nvtxNameCuDeviceW_fakeimpl_fntype)(nvtx_CUdevice device, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameCuContextA_fakeimpl_fntype)(nvtx_CUcontext context, const char* name);
+typedef void (NVTX_API * nvtxNameCuContextW_fakeimpl_fntype)(nvtx_CUcontext context, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameCuStreamA_fakeimpl_fntype)(nvtx_CUstream stream, const char* name);
+typedef void (NVTX_API * nvtxNameCuStreamW_fakeimpl_fntype)(nvtx_CUstream stream, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameCuEventA_fakeimpl_fntype)(nvtx_CUevent event, const char* name);
+typedef void (NVTX_API * nvtxNameCuEventW_fakeimpl_fntype)(nvtx_CUevent event, const wchar_t* name);
+
+/* Real impl types are defined in nvtxImplOpenCL_v3.h, where OPENCL headers are included */
+typedef void (NVTX_API * nvtxNameClDeviceA_fakeimpl_fntype)(nvtx_cl_device_id device, const char* name);
+typedef void (NVTX_API * nvtxNameClDeviceW_fakeimpl_fntype)(nvtx_cl_device_id device, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameClContextA_fakeimpl_fntype)(nvtx_cl_context context, const char* name);
+typedef void (NVTX_API * nvtxNameClContextW_fakeimpl_fntype)(nvtx_cl_context context, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameClCommandQueueA_fakeimpl_fntype)(nvtx_cl_command_queue command_queue, const char* name);
+typedef void (NVTX_API * nvtxNameClCommandQueueW_fakeimpl_fntype)(nvtx_cl_command_queue command_queue, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameClMemObjectA_fakeimpl_fntype)(nvtx_cl_mem memobj, const char* name);
+typedef void (NVTX_API * nvtxNameClMemObjectW_fakeimpl_fntype)(nvtx_cl_mem memobj, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameClSamplerA_fakeimpl_fntype)(nvtx_cl_sampler sampler, const char* name);
+typedef void (NVTX_API * nvtxNameClSamplerW_fakeimpl_fntype)(nvtx_cl_sampler sampler, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameClProgramA_fakeimpl_fntype)(nvtx_cl_program program, const char* name);
+typedef void (NVTX_API * nvtxNameClProgramW_fakeimpl_fntype)(nvtx_cl_program program, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameClEventA_fakeimpl_fntype)(nvtx_cl_event evnt, const char* name);
+typedef void (NVTX_API * nvtxNameClEventW_fakeimpl_fntype)(nvtx_cl_event evnt, const wchar_t* name);
+
+/* Real impl types are defined in nvtxImplCudaRt_v3.h, where CUDART headers are included */
+typedef void (NVTX_API * nvtxNameCudaDeviceA_fakeimpl_fntype)(int device, const char* name);
+typedef void (NVTX_API * nvtxNameCudaDeviceW_fakeimpl_fntype)(int device, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameCudaStreamA_fakeimpl_fntype)(nvtx_cudaStream_t stream, const char* name);
+typedef void (NVTX_API * nvtxNameCudaStreamW_fakeimpl_fntype)(nvtx_cudaStream_t stream, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameCudaEventA_fakeimpl_fntype)(nvtx_cudaEvent_t event, const char* name);
+typedef void (NVTX_API * nvtxNameCudaEventW_fakeimpl_fntype)(nvtx_cudaEvent_t event, const wchar_t* name);
+
+typedef void (NVTX_API * nvtxDomainMarkEx_impl_fntype)(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+typedef nvtxRangeId_t (NVTX_API * nvtxDomainRangeStartEx_impl_fntype)(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+typedef void (NVTX_API * nvtxDomainRangeEnd_impl_fntype)(nvtxDomainHandle_t domain, nvtxRangeId_t id);
+typedef int (NVTX_API * nvtxDomainRangePushEx_impl_fntype)(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
+typedef int (NVTX_API * nvtxDomainRangePop_impl_fntype)(nvtxDomainHandle_t domain);
+typedef nvtxResourceHandle_t (NVTX_API * nvtxDomainResourceCreate_impl_fntype)(nvtxDomainHandle_t domain, nvtxResourceAttributes_t* attribs);
+typedef void (NVTX_API * nvtxDomainResourceDestroy_impl_fntype)(nvtxResourceHandle_t resource);
+typedef void (NVTX_API * nvtxDomainNameCategoryA_impl_fntype)(nvtxDomainHandle_t domain, uint32_t category, const char* name);
+typedef void (NVTX_API * nvtxDomainNameCategoryW_impl_fntype)(nvtxDomainHandle_t domain, uint32_t category, const wchar_t* name);
+typedef nvtxStringHandle_t (NVTX_API * nvtxDomainRegisterStringA_impl_fntype)(nvtxDomainHandle_t domain, const char* string);
+typedef nvtxStringHandle_t (NVTX_API * nvtxDomainRegisterStringW_impl_fntype)(nvtxDomainHandle_t domain, const wchar_t* string);
+typedef nvtxDomainHandle_t (NVTX_API * nvtxDomainCreateA_impl_fntype)(const char* message);
+typedef nvtxDomainHandle_t (NVTX_API * nvtxDomainCreateW_impl_fntype)(const wchar_t* message);
+typedef void (NVTX_API * nvtxDomainDestroy_impl_fntype)(nvtxDomainHandle_t domain);
+typedef void (NVTX_API * nvtxInitialize_impl_fntype)(const void* reserved);
+
+typedef nvtx_nvtxSyncUser_t (NVTX_API * nvtxDomainSyncUserCreate_fakeimpl_fntype)(nvtxDomainHandle_t domain, const nvtx_nvtxSyncUserAttributes_t* attribs);
+typedef void (NVTX_API * nvtxDomainSyncUserDestroy_fakeimpl_fntype)(nvtx_nvtxSyncUser_t handle);
+typedef void (NVTX_API * nvtxDomainSyncUserAcquireStart_fakeimpl_fntype)(nvtx_nvtxSyncUser_t handle);
+typedef void (NVTX_API * nvtxDomainSyncUserAcquireFailed_fakeimpl_fntype)(nvtx_nvtxSyncUser_t handle);
+typedef void (NVTX_API * nvtxDomainSyncUserAcquireSuccess_fakeimpl_fntype)(nvtx_nvtxSyncUser_t handle);
+typedef void (NVTX_API * nvtxDomainSyncUserReleasing_fakeimpl_fntype)(nvtx_nvtxSyncUser_t handle);
+
+/* ---------------- Types for callback subscription --------------------- */
+
+typedef const void *(NVTX_API * NvtxGetExportTableFunc_t)(uint32_t exportTableId);
+typedef int (NVTX_API * NvtxInitializeInjectionNvtxFunc_t)(NvtxGetExportTableFunc_t exportTable);
+
+typedef enum NvtxCallbackModule
+{
+    NVTX_CB_MODULE_INVALID                 = 0,
+    NVTX_CB_MODULE_CORE                    = 1,
+    NVTX_CB_MODULE_CUDA                    = 2,
+    NVTX_CB_MODULE_OPENCL                  = 3,
+    NVTX_CB_MODULE_CUDART                  = 4,
+    NVTX_CB_MODULE_CORE2                   = 5,
+    NVTX_CB_MODULE_SYNC                    = 6,
+    /* --- New constants must only be added directly above this line --- */
+    NVTX_CB_MODULE_SIZE,
+    NVTX_CB_MODULE_FORCE_INT               = 0x7fffffff
+} NvtxCallbackModule;
+
+typedef enum NvtxCallbackIdCore
+{
+    NVTX_CBID_CORE_INVALID                 =  0,
+    NVTX_CBID_CORE_MarkEx                  =  1,
+    NVTX_CBID_CORE_MarkA                   =  2,
+    NVTX_CBID_CORE_MarkW                   =  3,
+    NVTX_CBID_CORE_RangeStartEx            =  4,
+    NVTX_CBID_CORE_RangeStartA             =  5,
+    NVTX_CBID_CORE_RangeStartW             =  6,
+    NVTX_CBID_CORE_RangeEnd                =  7,
+    NVTX_CBID_CORE_RangePushEx             =  8,
+    NVTX_CBID_CORE_RangePushA              =  9,
+    NVTX_CBID_CORE_RangePushW              = 10,
+    NVTX_CBID_CORE_RangePop                = 11,
+    NVTX_CBID_CORE_NameCategoryA           = 12,
+    NVTX_CBID_CORE_NameCategoryW           = 13,
+    NVTX_CBID_CORE_NameOsThreadA           = 14,
+    NVTX_CBID_CORE_NameOsThreadW           = 15,
+    /* --- New constants must only be added directly above this line --- */
+    NVTX_CBID_CORE_SIZE,
+    NVTX_CBID_CORE_FORCE_INT = 0x7fffffff
+} NvtxCallbackIdCore;
+
+typedef enum NvtxCallbackIdCore2
+{
+    NVTX_CBID_CORE2_INVALID                 = 0,
+    NVTX_CBID_CORE2_DomainMarkEx            = 1,
+    NVTX_CBID_CORE2_DomainRangeStartEx      = 2,
+    NVTX_CBID_CORE2_DomainRangeEnd          = 3,
+    NVTX_CBID_CORE2_DomainRangePushEx       = 4,
+    NVTX_CBID_CORE2_DomainRangePop          = 5,
+    NVTX_CBID_CORE2_DomainResourceCreate    = 6,
+    NVTX_CBID_CORE2_DomainResourceDestroy   = 7,
+    NVTX_CBID_CORE2_DomainNameCategoryA     = 8,
+    NVTX_CBID_CORE2_DomainNameCategoryW     = 9,
+    NVTX_CBID_CORE2_DomainRegisterStringA   = 10,
+    NVTX_CBID_CORE2_DomainRegisterStringW   = 11,
+    NVTX_CBID_CORE2_DomainCreateA           = 12,
+    NVTX_CBID_CORE2_DomainCreateW           = 13,
+    NVTX_CBID_CORE2_DomainDestroy           = 14,
+    NVTX_CBID_CORE2_Initialize              = 15,
+    /* --- New constants must only be added directly above this line --- */
+    NVTX_CBID_CORE2_SIZE,
+    NVTX_CBID_CORE2_FORCE_INT               = 0x7fffffff
+} NvtxCallbackIdCore2;
+
+typedef enum NvtxCallbackIdCuda
+{
+    NVTX_CBID_CUDA_INVALID                 =  0,
+    NVTX_CBID_CUDA_NameCuDeviceA           =  1,
+    NVTX_CBID_CUDA_NameCuDeviceW           =  2,
+    NVTX_CBID_CUDA_NameCuContextA          =  3,
+    NVTX_CBID_CUDA_NameCuContextW          =  4,
+    NVTX_CBID_CUDA_NameCuStreamA           =  5,
+    NVTX_CBID_CUDA_NameCuStreamW           =  6,
+    NVTX_CBID_CUDA_NameCuEventA            =  7,
+    NVTX_CBID_CUDA_NameCuEventW            =  8,
+    /* --- New constants must only be added directly above this line --- */
+    NVTX_CBID_CUDA_SIZE,
+    NVTX_CBID_CUDA_FORCE_INT               = 0x7fffffff
+} NvtxCallbackIdCuda;
+
+typedef enum NvtxCallbackIdCudaRt
+{
+    NVTX_CBID_CUDART_INVALID               =  0,
+    NVTX_CBID_CUDART_NameCudaDeviceA       =  1,
+    NVTX_CBID_CUDART_NameCudaDeviceW       =  2,
+    NVTX_CBID_CUDART_NameCudaStreamA       =  3,
+    NVTX_CBID_CUDART_NameCudaStreamW       =  4,
+    NVTX_CBID_CUDART_NameCudaEventA        =  5,
+    NVTX_CBID_CUDART_NameCudaEventW        =  6,
+    /* --- New constants must only be added directly above this line --- */
+    NVTX_CBID_CUDART_SIZE,
+    NVTX_CBID_CUDART_FORCE_INT             = 0x7fffffff
+} NvtxCallbackIdCudaRt;
+
+typedef enum NvtxCallbackIdOpenCL
+{
+    NVTX_CBID_OPENCL_INVALID               =  0,
+    NVTX_CBID_OPENCL_NameClDeviceA         =  1,
+    NVTX_CBID_OPENCL_NameClDeviceW         =  2,
+    NVTX_CBID_OPENCL_NameClContextA        =  3,
+    NVTX_CBID_OPENCL_NameClContextW        =  4,
+    NVTX_CBID_OPENCL_NameClCommandQueueA   =  5,
+    NVTX_CBID_OPENCL_NameClCommandQueueW   =  6,
+    NVTX_CBID_OPENCL_NameClMemObjectA      =  7,
+    NVTX_CBID_OPENCL_NameClMemObjectW      =  8,
+    NVTX_CBID_OPENCL_NameClSamplerA        =  9,
+    NVTX_CBID_OPENCL_NameClSamplerW        = 10,
+    NVTX_CBID_OPENCL_NameClProgramA        = 11,
+    NVTX_CBID_OPENCL_NameClProgramW        = 12,
+    NVTX_CBID_OPENCL_NameClEventA          = 13,
+    NVTX_CBID_OPENCL_NameClEventW          = 14,
+    /* --- New constants must only be added directly above this line --- */
+    NVTX_CBID_OPENCL_SIZE,
+    NVTX_CBID_OPENCL_FORCE_INT             = 0x7fffffff
+} NvtxCallbackIdOpenCL;
+
+typedef enum NvtxCallbackIdSync
+{
+    NVTX_CBID_SYNC_INVALID                      = 0,
+    NVTX_CBID_SYNC_DomainSyncUserCreate         = 1,
+    NVTX_CBID_SYNC_DomainSyncUserDestroy        = 2,
+    NVTX_CBID_SYNC_DomainSyncUserAcquireStart   = 3,
+    NVTX_CBID_SYNC_DomainSyncUserAcquireFailed  = 4,
+    NVTX_CBID_SYNC_DomainSyncUserAcquireSuccess = 5,
+    NVTX_CBID_SYNC_DomainSyncUserReleasing      = 6,
+    /* --- New constants must only be added directly above this line --- */
+    NVTX_CBID_SYNC_SIZE,
+    NVTX_CBID_SYNC_FORCE_INT                    = 0x7fffffff
+} NvtxCallbackIdSync;
+
+/* IDs for NVTX Export Tables */
+typedef enum NvtxExportTableID
+{
+    NVTX_ETID_INVALID                      = 0,
+    NVTX_ETID_CALLBACKS                    = 1,
+    NVTX_ETID_RESERVED0                    = 2,
+    NVTX_ETID_VERSIONINFO                  = 3,
+    /* --- New constants must only be added directly above this line --- */
+    NVTX_ETID_SIZE,
+    NVTX_ETID_FORCE_INT                    = 0x7fffffff
+} NvtxExportTableID;
+
+typedef void (* NvtxFunctionPointer)(void); /* generic uncallable function pointer, must be cast to appropriate function type */
+typedef NvtxFunctionPointer** NvtxFunctionTable; /* double pointer because array(1) of pointers(2) to function pointers */
+
+typedef struct NvtxExportTableCallbacks
+{
+    size_t struct_size;
+
+    /* returns an array of pointer to function pointers*/
+    int (NVTX_API *GetModuleFunctionTable)(
+        NvtxCallbackModule callback_module,
+        NvtxFunctionTable* out_table,
+        unsigned int* out_size);
+} NvtxExportTableCallbacks;
+
+typedef struct NvtxExportTableVersionInfo
+{
+    /* sizeof(NvtxExportTableVersionInfo) */
+    size_t struct_size;
+
+    /* The API version comes from the NVTX library linked to the app.  The
+    * injection library is can use this info to make some assumptions */
+    uint32_t version;
+
+    /* Reserved for alignment, do not use */
+    uint32_t reserved0;
+
+    /* This must be set by tools when attaching to provide applications
+    *  the ability to, in emergency situations, detect problematic tools
+    *  versions and modify the NVTX source to prevent attaching anything
+    *  that causes trouble in the app.  Currently, this value is ignored. */
+    void (NVTX_API *SetInjectionNvtxVersion)(
+        uint32_t version);
+} NvtxExportTableVersionInfo;

--- a/window.cpp
+++ b/window.cpp
@@ -31,6 +31,7 @@
 #include "Globals.h"
 #include "AppShutdown.h"
 #include "main.h" // For RequestIDRNow
+#include <nvtx3/nvtx3.hpp>
 
 // ==== [Multi-monitor helpers - BEGIN] ====
 #ifndef _USE_MATH_DEFINES
@@ -1178,6 +1179,7 @@ static void ResizeSwapChainOnRenderThread(int newW, int newH) {
 }
 
 void RenderFrame() {
+    nvtx3::scoped_range r("D3D12Present");
     // ---- [Release completed frame resources - BEGIN] ----
     // GPUがどこまで処理を終えたかを確認
     const UINT64 completedFenceValue = g_fence->GetCompletedValue();


### PR DESCRIPTION
This change introduces NVTX ranges to help profile the application using NVIDIA Nsight Systems.

- Added NVTX v3 header files to the `third_party` directory.
- Updated `CMakeLists.txt` to include the NVTX headers.
- Added NVTX ranges to the following sections:
  - `Initialization`: In `wWinMain` to cover the application setup.
  - `CUDA Decode`: In `NvdecThread` to cover the video decoding process.
  - `D3D12Present`: In `RenderFrame` to cover the rendering and presentation.