### PR TITLE
Resolve NVTX header version conflict by reordering includes.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -52,6 +52,7 @@ using namespace DebugLogAsync;
 #include <sstream>
 #include "concurrentqueue/concurrentqueue.h"
 #include <enet/enet.h>
+#include <nvtx3/nvtx3.hpp>
 #include "Globals.h"
 #include "nvdec.h"
 #include "AppShutdown.h"
@@ -59,7 +60,6 @@ using namespace DebugLogAsync;
 #include <cuda_runtime_api.h>
 #include <d3dx12.h>
 #include <d3d12.h>
-#include <nvtx3/nvtx3.hpp>
 
 // === 新規：ネットワーク準備・解像度ペンディング管理 ===
 std::atomic<bool> g_networkReady{false};

--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -1,3 +1,4 @@
+#include <nvtx3/nvtx3.hpp>
 #include "nvdec.h"
 #include "Globals.h"
 #include <stdexcept>
@@ -8,7 +9,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <nvtx3/nvtx3.hpp>
 
 // Use a single monotonic clock for all latency metrics.
 static inline uint64_t SteadyNowMs() noexcept {


### PR DESCRIPTION
The compilation was failing with an error indicating that NVTX version 3 was being included after an older version of NVTX had already been included.

This was caused by headers such as `<cuda.h>` or `<nvcuvid.h>` implicitly including an older NVTX header before `<nvtx3/nvtx3.hpp>` was explicitly included.

The fix is to move `#include <nvtx3/nvtx3.hpp>` to the top of the include list in `main.cpp` and `nvdec.cpp`, ensuring the v3 header is processed first, as recommended by the error message.