### PR TITLE
Fix NVTX header version conflict during compilation.

### DIFF
--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -1,4 +1,3 @@
-#include <nvtx3/nvtx3.hpp>
 #include "nvdec.h"
 #include "Globals.h"
 #include <stdexcept>

--- a/nvdec.h
+++ b/nvdec.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nvtx3/nvtx3.hpp>
 #include <d3d12.h>
 #include <wrl/client.h>
 #include <vector>

--- a/window.cpp
+++ b/window.cpp
@@ -1,5 +1,6 @@
 #define WIN32_LEAN_AND_MEAN // winsock.h の含まれる量を減らす
 #define NOMINMAX
+#include <nvtx3/nvtx3.hpp>
 #include <d3dcompiler.h> // For shader compilation
 #include <DirectXColors.h> // For DirectX::Colors
 #include <windows.h>
@@ -31,7 +32,6 @@
 #include "Globals.h"
 #include "AppShutdown.h"
 #include "main.h" // For RequestIDRNow
-#include <nvtx3/nvtx3.hpp>
 
 // ==== [Multi-monitor helpers - BEGIN] ====
 #ifndef _USE_MATH_DEFINES


### PR DESCRIPTION
The compilation was failing with an error indicating that an older version of the NVTX header was being included before the newer v3 header. This caused a preprocessor `#error` to be triggered in `nvtx3/nvToolsExt.h`.

The fix involves ensuring that the NVTX v3 header (`nvtx3/nvtx3.hpp`) is always included before any other headers that might pull in an older version (such as CUDA or DirectX headers).

- In `window.cpp`, the `<nvtx3/nvtx3.hpp>` include was moved to the top of the file.
- For `nvdec.cpp`, the include was moved from the `.cpp` file to the corresponding header, `nvdec.h`, and placed at the top. This ensures any file including the CUDA/NVDEC functionality gets the correct NVTX header first.