### PR TITLE
build: Fix NVTX version conflict error C1189

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,9 @@ set(HEADERS
 # 実行ファイルを作成
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 
+# NVTX v3ヘッダを強制的にインクルードして、バージョン競合エラー(C1189)を解決する
+target_compile_options(${PROJECT_NAME} PRIVATE "/FInvtx3/nvtx3.hpp")
+
 # ライブラリのリンク
 target_link_libraries(${PROJECT_NAME}
     # Windows基本ライブラリ


### PR DESCRIPTION
The build was failing with an error indicating that an older version of the NVTX library was being included before NVTX v3. This is caused by the `LANGUAGES CUDA` property in CMake, which injects CUDA-related settings project-wide.

To resolve this, force-include the NVTX v3 header (`nvtx3/nvtx3.hpp`) for all compilation units using the MSVC compiler flag `/FI`. This ensures the v3 header is always processed first, satisfying the preprocessor checks and resolving the version conflict.