### PR TITLE
feat: Add NVTX markers for performance profiling

### DIFF
--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -593,6 +593,7 @@ UINT64 HandlePictureDisplayCount = 0;
 int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDispInfo) {
     FrameDecoder* const self = static_cast<FrameDecoder*>(pUserData);
     cuCtxPushCurrent(self->m_cuContext);
+    nvtxRangePushA("Decode");
 
     // RAII locker for the context lock. It will be unlocked automatically.
     CudaCtxLocker ctxLocker(self->m_ctxLock);
@@ -743,6 +744,7 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
     }
     g_readyGpuFrameQueueCV.notify_one();
 
+    nvtxRangePop();
     cuCtxPopCurrent(NULL);
     return 1;
 }


### PR DESCRIPTION
Introduces NVTX (NVIDIA Tools Extension) markers to key areas of the application for performance profiling with tools like NVIDIA Nsight.

Frame-based Profiling:
- Adds a `Frame` range to wrap the main rendering logic.
- Adds nested `Decode`, `Render`, and `Present` ranges to measure the time spent in each stage of the pipeline.

Network Profiling:
- Adds a `WaitRecv` range to measure time spent waiting for network packets.
- Adds a `ProcessPacket` range to measure packet processing time.

This provides a hierarchical view of performance, as requested, to help identify bottlenecks.