### PR TITLE
chore(nvtx/render): tighten NVTX to per-frame; keep bounded fence wai…

### DIFF
--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -593,7 +593,7 @@ UINT64 HandlePictureDisplayCount = 0;
 int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDispInfo) {
     FrameDecoder* const self = static_cast<FrameDecoder*>(pUserData);
     cuCtxPushCurrent(self->m_cuContext);
-    nvtxRangePushA("Decode");
+    nvtx3::scoped_range r_decode_copy("DecodeCopy");
 
     // RAII locker for the context lock. It will be unlocked automatically.
     CudaCtxLocker ctxLocker(self->m_ctxLock);
@@ -744,7 +744,6 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
     }
     g_readyGpuFrameQueueCV.notify_one();
 
-    nvtxRangePop();
     cuCtxPopCurrent(NULL);
     return 1;
 }


### PR DESCRIPTION
…t; periodic fragment TTL cleanup

- Removed broad, process-wide 'Initialization' NVTX range to declutter timelines.
- Converted all manual nvtxRangePush/Pop calls to RAII-style nvtx3::scoped_range for exception safety and to prevent unbalanced ranges.
- Added specific, per-frame NVTX markers for 'PopulateCommandList' and 'Present' to isolate these key stages in profiling tools.
- Added a guard to OnNetworkReady() to prevent redundant resolution announcements and IDR requests on multiple client connect events.

The existing logic for the render fence, in-flight frame limits, and forced-present path was preserved as per requirements. The periodic call to ClearTimedOutAppFragments() was confirmed to be present and was not modified. The decoder reconfiguration policy and reorder state clearing were also confirmed to be correct and were not modified.