### PR TITLE
feat: Improve frame pacing and NVTX telemetry

### DIFF
--- a/nvtx_helpers.h
+++ b/nvtx_helpers.h
@@ -1,0 +1,25 @@
+#pragma once
+#ifdef ENABLE_NVTX
+  #include <nvtx3/nvToolsExt.h>
+  inline void nvtxPushU64(const char* name, uint64_t id, uint32_t color=0) {
+    nvtxEventAttributes_t a = {};
+    a.version = NVTX_VERSION; a.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    a.messageType = NVTX_MESSAGE_TYPE_ASCII; a.message.ascii = name;
+    a.colorType = color ? NVTX_COLOR_ARGB : NVTX_COLOR_UNKNOWN; a.color = color;
+    a.payloadType = NVTX_PAYLOAD_TYPE_UNSIGNED_INT64; a.payload.ullValue = id;
+    nvtxRangePushEx(&a);
+  }
+  inline void nvtxPop() { nvtxRangePop(); }
+  inline void nvtxMarkU64(const char* name, uint64_t id, uint32_t color=0) {
+    nvtxEventAttributes_t a = {};
+    a.version = NVTX_VERSION; a.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    a.messageType = NVTX_MESSAGE_TYPE_ASCII; a.message.ascii = name;
+    a.colorType = color ? NVTX_COLOR_ARGB : NVTX_COLOR_UNKNOWN; a.color = color;
+    a.payloadType = NVTX_PAYLOAD_TYPE_UNSIGNED_INT64; a.payload.ullValue = id;
+    nvtxMarkEx(&a);
+  }
+#else
+  inline void nvtxPushU64(const char*, uint64_t, uint32_t=0) {}
+  inline void nvtxPop() {}
+  inline void nvtxMarkU64(const char*, uint64_t, uint32_t=0) {}
+#endif


### PR DESCRIPTION
Implements several performance and debugging improvements for the D3D12 video client.

- Adds DXGI waitable swap chain for smoother frame pacing and reduced latency variance. Sets max frame latency to 1 and waits on the handle before rendering a new frame.
- Formalizes the in-flight frame budget with a named constant `kMaxInFlightFrames` to prevent the CPU from getting too far ahead of the GPU.
- Stabilizes shader resource view (SRV) allocation by pre-allocating slots for each backbuffer, reducing handle churn.
- Adds extensive, frame-correlated NVTX markers and ranges to improve debugging and performance analysis of decode, reorder, and render stages.
- Introduces `nvtx_helpers.h` for convenient and compile-time-switchable NVTX calls.
- Names the render and decoder threads for easier identification in profiling tools.