### PR TITLE
Fix multiple C++ compilation errors

### DIFF
--- a/ReedSolomon.cpp
+++ b/ReedSolomon.cpp
@@ -121,7 +121,7 @@ bool DecodeFEC_Jerasure(
     // ※ jerasure_bitmatrix_decode を使用 ※
     // The last two arguments are data_ptrs and coding_ptrs. Erasures must come before them.
     // The 'row_k_ones' parameter is not used in this decoding mode, set to 0.
-    int ret = jerasure_bitmatrix_decode(k, m, 8, const_cast<int*>(bitmatrix), 0, erasures.data(), data_ptrs.data(), coding_ptrs.data(), static_cast<int>(shard_len));
+    int ret = jerasure_bitmatrix_decode(k, m, 8, const_cast<int*>(bitmatrix), 0, erasures.data(), data_ptrs.data(), coding_ptrs.data(), static_cast<int>(shard_len), static_cast<int>(shard_len / 8));
     if (ret != 0) { // Jerasure returns 0 on success, -1 on failure.
         DebugLog(L"DecodeFEC_Jerasure Error: jerasure_bitmatrix_decode failed. Return code: " + std::to_wstring(ret));
         return false; // デコード失敗

--- a/main.cpp
+++ b/main.cpp
@@ -42,6 +42,7 @@ static inline uint64_t SteadyNowMs() noexcept {
 #include <queue>
 #include <condition_variable>
 #include "DebugLog.h"
+#include "nvtx_helpers.h" // For custom NVTX ranges and markers
 // 追加：非同期ロガー初期化/終了用
 using namespace DebugLogAsync;
 #include "ReedSolomon.h"

--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -295,7 +295,7 @@ int FrameDecoder::HandleVideoSequence(void* pUserData, CUVIDEOFORMAT* pVideoForm
             // Target display size is a renderer concern; decoder operates at coded size.
 
             if (needsReconfig) {
-                nvtxMarkU64("DecoderReconfig", (uint64_t)pVideoFormat->coded_width << 16 | pVideoFormat->coded_height, 0xFFFFFF00);
+                NvtxMark("DecoderReconfig", (uint64_t)pVideoFormat->coded_width << 16 | pVideoFormat->coded_height, NvtxCategory::Decode, 0xFFFFFF00);
                 if (!self->reconfigureDecoder(pVideoFormat)) {
                     DebugLog(L"HandleVideoSequence: Failed to reconfigure decoder.");
                     result = 0; // Stop processing

--- a/nvtx_helpers.h
+++ b/nvtx_helpers.h
@@ -2,16 +2,13 @@
 #pragma once
 #include <nvtx3/nvtx3.hpp>
 
-// Define domains and categories centrally
-// Per brief: domain "RemoteClient", categories: Net=1, Decode=2, Render=3, Present=4
-namespace NvtxDomains {
-    // Using a function ensures the domain object is initialized before first use.
-    inline nvtx3::domain& remote_client() {
-        static nvtx3::domain d{"RemoteClient"};
-        return d;
-    }
-}
+// Define a domain for the application.
+// This is done by creating a type with a static `name` member.
+struct remote_client_domain {
+    static constexpr char const* name = "RemoteClient";
+};
 
+// Define categories for events.
 enum class NvtxCategory : uint32_t {
     None = 0,
     Net = 1,
@@ -20,36 +17,40 @@ enum class NvtxCategory : uint32_t {
     Present = 4
 };
 
-// A simple RAII wrapper for NVTX ranges that supports domains, categories, and colors.
+// A RAII wrapper for NVTX ranges within our application's domain.
 struct NvtxRange {
-    nvtx3::scoped_range_in range; // scoped_range_in is required for domains
+    // The scoped_range_in must be templated with the domain type.
+    nvtx3::scoped_range_in<remote_client_domain> range;
 
     // Constructor with category and optional color.
+    // It constructs the `range` member by passing attribute objects.
     explicit NvtxRange(const char* name, NvtxCategory cat = NvtxCategory::None, uint32_t colorARGB = 0)
-      : range{ NvtxDomains::remote_client(),
-               nvtx3::name{name},
-               nvtx3::category{static_cast<uint32_t>(cat)},
-               nvtx3::color{colorARGB},
-               nvtx3::payload{(uint64_t)0} // Default payload, can be set later if needed.
-              }
+      : range{
+            nvtx3::message{name},
+            nvtx3::category{static_cast<uint32_t>(cat)},
+            nvtx3::color{nvtx3::argb{colorARGB}},
+            nvtx3::payload{(uint64_t)0}
+        }
     {}
 
     // Constructor with a payload.
     explicit NvtxRange(const char* name, uint64_t payload, NvtxCategory cat = NvtxCategory::None, uint32_t colorARGB = 0)
-    : range{ NvtxDomains::remote_client(),
-             nvtx3::name{name},
-             nvtx3::category{static_cast<uint32_t>(cat)},
-             nvtx3::color{colorARGB},
-             nvtx3::payload{payload}
-            }
+    : range{
+        nvtx3::message{name},
+        nvtx3::category{static_cast<uint32_t>(cat)},
+        nvtx3::color{nvtx3::argb{colorARGB}},
+        nvtx3::payload{payload}
+    }
     {}
 };
 
-// Standalone mark function for events.
+// Standalone mark function for events within our application's domain.
 inline void NvtxMark(const char* name, uint64_t payload, NvtxCategory cat = NvtxCategory::None, uint32_t colorARGB = 0) {
-    nvtx3::mark(NvtxDomains::remote_client(),
-                nvtx3::name{name},
-                nvtx3::category{static_cast<uint32_t>(cat)},
-                nvtx3::color{colorARGB},
-                nvtx3::payload{payload});
+    // Use `mark_in` with our domain as a template parameter.
+    nvtx3::mark_in<remote_client_domain>(
+        nvtx3::message{name},
+        nvtx3::category{static_cast<uint32_t>(cat)},
+        nvtx3::color{nvtx3::argb{colorARGB}},
+        nvtx3::payload{payload}
+    );
 }

--- a/window.cpp
+++ b/window.cpp
@@ -461,13 +461,13 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) 
             return 0;
 
         case WM_ENTERSIZEMOVE:
-            nvtxMarkU64("ResizeStart", 0, 0);
+            NvtxMark("ResizeStart", 0, NvtxCategory::Render, 0);
             g_isSizing = true;
             return 0;
 
         case WM_EXITSIZEMOVE:
         {
-            nvtxMarkU64("ResizeEnd", 0, 0);
+            NvtxMark("ResizeEnd", 0, NvtxCategory::Render, 0);
             g_isSizing = false;
 
             // 1) Finalize and FORCE the resolution announce at drag end.
@@ -1027,7 +1027,7 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
             // Buffer is full, we must advance to prevent a stall.
             auto jt = g_reorderBuffer.begin(); // Smallest available frame ID
             DebugLog(L"[REORDER] Buffer full. Jumping from expected " + std::to_wstring(g_expectedStreamFrame) + L" to " + std::to_wstring(jt->first));
-            nvtxMarkU64("ReorderDecision::Jump", jt->first, 0xFFFFA500);
+            NvtxMark("ReorderDecision::Jump", jt->first, NvtxCategory::Render, 0xFFFFA500);
             outFrameToRender = std::move(jt->second);
             g_expectedStreamFrame = jt->first + 1;
             g_reorderBuffer.erase(jt);


### PR DESCRIPTION
This commit addresses several build errors that were preventing the project from compiling successfully.

- In `ReedSolomon.cpp`, the call to `jerasure_bitmatrix_decode` was missing its final `packetsize` argument. This has been corrected by adding the argument, consistent with the function's usage elsewhere in the file.

- The NVTX helper file, `nvtx_helpers.h`, was using an outdated or incorrect approach for the NVTX v3 C++ API. The file has been rewritten to use the modern, type-safe C++ wrappers. This includes defining a domain as a type, using template parameters for domain-specific calls, and using the correct attribute classes (`nvtx3::message`, `nvtx3::color`, etc.).

- `main.cpp` was missing the include for `nvtx_helpers.h`, causing 'undeclared identifier' errors for the custom NVTX types. The header is now included.

- `nvdec.cpp` and `window.cpp` contained calls to a non-existent `nvtxMarkU64` function. These have been replaced with calls to the correct `NvtxMark` function defined in the updated helper header.