### PR TITLE
Fix NVTX compilation error in nvtx_helpers.h

### DIFF
--- a/nvtx_helpers.h
+++ b/nvtx_helpers.h
@@ -28,7 +28,7 @@ struct NvtxRange {
       : range{
             nvtx3::message{name},
             nvtx3::category{static_cast<uint32_t>(cat)},
-            nvtx3::color{nvtx3::argb{colorARGB}},
+            nvtx3::color{colorARGB},
             nvtx3::payload{(uint64_t)0}
         }
     {}
@@ -38,7 +38,7 @@ struct NvtxRange {
     : range{
         nvtx3::message{name},
         nvtx3::category{static_cast<uint32_t>(cat)},
-        nvtx3::color{nvtx3::argb{colorARGB}},
+        nvtx3::color{colorARGB},
         nvtx3::payload{payload}
     }
     {}
@@ -50,7 +50,7 @@ inline void NvtxMark(const char* name, uint64_t payload, NvtxCategory cat = Nvtx
     nvtx3::mark_in<remote_client_domain>(
         nvtx3::message{name},
         nvtx3::category{static_cast<uint32_t>(cat)},
-        nvtx3::color{nvtx3::argb{colorARGB}},
+        nvtx3::color{colorARGB},
         nvtx3::payload{payload}
     );
 }


### PR DESCRIPTION
The constructor for `nvtx3::color` was being called incorrectly with an `nvtx3::argb` object that was created from a `uint32_t`.

The `nvtx3::argb` class does not have a constructor that accepts a `uint32_t`. The correct way to create a color from a `uint32_t` ARGB value is to pass it directly to the `nvtx3::color` constructor.

This change updates the calls in `nvtx_helpers.h` to use the correct constructor, resolving the C2440 compilation error.