### PR TITLE
A null pointer exception could occur in `PopulateCommandList` if the …

### DIFF
--- a/window.cpp
+++ b/window.cpp
@@ -930,6 +930,12 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
     if (FAILED(hr)) { DebugLog(L"PopulateCommandList: Failed to reset command list. HR: " + HResultToHexWString(hr)); return false; }
 
     // Transition the current back buffer from PRESENT to RENDER_TARGET.
+    if (!g_renderTargets[g_currentFrameBufferIndex]) {
+        // This can happen during a resize when the swap chain is being recreated.
+        // We close the command list and return, skipping rendering for this frame.
+        g_commandList->Close();
+        return false;
+    }
     D3D12_RESOURCE_BARRIER barrier = {};
     barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
     barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;


### PR DESCRIPTION
…window was resized and the underlying swap chain resize operation failed. This would leave the D3D12 render targets in a null state, causing a crash when accessed.

This change adds a null check for the render target resource before it is used. If the resource is null, the command list is closed and the frame is skipped, preventing the crash and allowing the application to recover.

This addresses the exception that originates from `nvcuda64.dll` during a resize.