### PR TITLE
Fix(window): Correct NVTX API usage to resolve compilation errors

### DIFF
--- a/window.cpp
+++ b/window.cpp
@@ -997,8 +997,8 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
 
     // 2) N と N+1 がそろったら N を描画。なければ短い待ち or 圧迫で妥協
     {
-        static nvtx3::domain g_nvtx_reorder{"REORDER"};
-        nvtx3::scoped_range_in<g_nvtx_reorder> r{"Reorder(decide)"};
+        struct reorder_domain { static constexpr char const* name = "REORDER"; };
+        nvtx3::scoped_range_in<reorder_domain> r{"Reorder(decide)"};
         std::lock_guard<std::mutex> rlock(g_reorderMutex);
         auto now = std::chrono::steady_clock::now();
 


### PR DESCRIPTION
The previous code failed to compile because it was using the NVTX3 C++ API incorrectly. It tried to instantiate `nvtx3::domain` directly, which has a private constructor, leading to error C2248. It also used the resulting object as a template parameter, which is invalid and caused error C2923.

This change corrects the API usage by defining a local struct for the 'REORDER' domain and using this type as the template parameter for `nvtx3::scoped_range_in`. This aligns with the correct usage pattern demonstrated elsewhere in the codebase for other NVTX domains and resolves the compilation errors.