### PR TITLE
Fix: Correct C++ compilation errors

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -765,6 +765,8 @@ void CountBandW() {
 }
 
 
+struct nvtx_domain_net { static constexpr char const* name = "NET"; };
+
 void ReceiveRawPacketsThread(int threadId) { // Renaming to ReceiveENetPacketsThread would be clearer
     DebugLog(L"ReceiveRawPacketsThread [" + std::to_wstring(threadId) + L"] started.");
 
@@ -798,10 +800,9 @@ void ReceiveRawPacketsThread(int threadId) { // Renaming to ReceiveENetPacketsTh
     while (receive_raw_packet_Running) {
         
         // Service ENet events with a timeout (e.g., 10ms)
-        static nvtx3::domain g_nvtx_net{"NET"};
         int service_result;
         {
-            nvtx3::scoped_range_in<g_nvtx_net> r{"Net/WaitRecv"};
+            nvtx3::scoped_range_in<nvtx_domain_net> r{"Net/WaitRecv"};
             service_result = enet_host_service(server_host, &event, 10);
         }
 

--- a/window.cpp
+++ b/window.cpp
@@ -931,6 +931,7 @@ bool InitD3D() {
 }
 
 UINT64 PopulateCommandListCount = 0;
+struct reorder_domain { static constexpr char const* name = "REORDER"; };
 bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass ReadyGpuFrame by reference
     nvtx3::scoped_range_in<d3d12_domain> nvtx_populate_cmdlist{"PopulateCommandList"};
     // Reset command allocator and command list
@@ -997,7 +998,6 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
 
     // 2) N と N+1 がそろったら N を描画。なければ短い待ち or 圧迫で妥協
     {
-        struct reorder_domain { static constexpr char const* name = "REORDER"; };
         nvtx3::scoped_range_in<reorder_domain> r{"Reorder(decide)"};
         std::lock_guard<std::mutex> rlock(g_reorderMutex);
         auto now = std::chrono::steady_clock::now();


### PR DESCRIPTION
This commit addresses two separate compilation errors:

In `main.cpp`, corrected the usage of the NVTX3 library. The NVTX domain was being instantiated as a runtime object, which is not the correct pattern for `scoped_range_in`. A domain tag struct (`nvtx_domain_net`) has been introduced and is now used as a type template parameter, resolving errors C2248 and C2923.

In `window.cpp`, resolved error C2246 by moving the definition of the `reorder_domain` struct out of the `PopulateCommandList` function to file scope. C++ does not allow static data members in function-local classes.