### PR TITLE
Fix: Correct NVTX API usage to resolve compilation errors

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -768,7 +768,7 @@ void CountBandW() {
 }
 
 
-static nvtx3::domain g_nvtx_net{"NET"};
+static nvtx3::domain g_nvtx_net("NET");
 
 void ReceiveRawPacketsThread(int threadId) { // Renaming to ReceiveENetPacketsThread would be clearer
     DebugLog(L"ReceiveRawPacketsThread [" + std::to_wstring(threadId) + L"] started.");
@@ -805,7 +805,7 @@ void ReceiveRawPacketsThread(int threadId) { // Renaming to ReceiveENetPacketsTh
         // Service ENet events with a timeout (e.g., 10ms)
         int service_result;
         {
-            nvtx3::scoped_range_in<g_nvtx_net> r{"Net/WaitRecv(enet_service)"};
+            nvtx3::scoped_range_in r(g_nvtx_net, "Net/WaitRecv(enet_service)");
             service_result = enet_host_service(server_host, &event, NET_POLL_TIMEOUT_MS);
         }
 

--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -3,7 +3,7 @@
 #include <nvtx3/nvtx3.hpp>
 #include <stdexcept>
 
-static nvtx3::domain g_nvtx_nvdec{"NVDEC"};
+static nvtx3::domain g_nvtx_nvdec("NVDEC");
 #include <fstream>
 #include <vector>
 #include <algorithm>
@@ -657,7 +657,7 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
 
     // Y plane
     {
-        nvtx3::scoped_range_in<g_nvtx_nvdec> r{"CopyAsync(Y)"};
+        nvtx3::scoped_range_in r(g_nvtx_nvdec, "CopyAsync(Y)");
         CUDA_MEMCPY2D y = {};
         y.srcMemoryType = CU_MEMORYTYPE_DEVICE;
         y.srcDevice     = pDecodedFrame;
@@ -671,7 +671,7 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
 
     // UV plane
     {
-        nvtx3::scoped_range_in<g_nvtx_nvdec> r{"CopyAsync(UV)"};
+        nvtx3::scoped_range_in r(g_nvtx_nvdec, "CopyAsync(UV)");
         CUDA_MEMCPY2D uv = {};
         uv.srcMemoryType = CU_MEMORYTYPE_DEVICE;
         uv.srcDevice     = pDecodedFrame + (size_t)srcHeightRows_Y * nDecodedPitch;
@@ -685,7 +685,7 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
 
     // Record completion event for this frame
     {
-        nvtx3::scoped_range_in<g_nvtx_nvdec> r{"EventRecord(copyDone)"};
+        nvtx3::scoped_range_in r(g_nvtx_nvdec, "EventRecord(copyDone)");
         CUDA_CHECK_CALLBACK(cuEventRecord(fr.copyDone, s));
     }
 


### PR DESCRIPTION
This commit fixes C++ compilation errors C2248 and C2923, which were caused by incorrect usage of the NVTX v3 C++ wrapper API.

The `nvtx3::domain` static objects were being initialized using curly braces, which in some contexts can be ambiguous. This was changed to use parentheses to ensure direct-initialization.

The `nvtx3::scoped_range_in` class was being instantiated with the domain object passed as a template parameter. This is incorrect, as the template expects a type, not an object. The code has been changed to pass the domain object as a regular argument to the constructor of `scoped_range_in`, which is the intended usage pattern.

These changes were applied to both `main.cpp` and `nvdec.cpp` where the errors occurred.