### PR TITLE
Fix(nvtx): Update NVTX domain creation to fix compilation error

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -768,7 +768,11 @@ void CountBandW() {
 }
 
 
-static nvtx3::domain g_nvtx_net("NET");
+namespace my_nvtx_domains {
+    struct net {
+        static constexpr char const* name = "NET";
+    };
+}
 
 void ReceiveRawPacketsThread(int threadId) { // Renaming to ReceiveENetPacketsThread would be clearer
     DebugLog(L"ReceiveRawPacketsThread [" + std::to_wstring(threadId) + L"] started.");
@@ -805,7 +809,7 @@ void ReceiveRawPacketsThread(int threadId) { // Renaming to ReceiveENetPacketsTh
         // Service ENet events with a timeout (e.g., 10ms)
         int service_result;
         {
-            nvtx3::scoped_range_in r(g_nvtx_net, "Net/WaitRecv(enet_service)");
+            nvtx3::scoped_range_in<my_nvtx_domains::net> r("Net/WaitRecv(enet_service)");
             service_result = enet_host_service(server_host, &event, NET_POLL_TIMEOUT_MS);
         }
 

--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -3,7 +3,12 @@
 #include <nvtx3/nvtx3.hpp>
 #include <stdexcept>
 
-static nvtx3::domain g_nvtx_nvdec("NVDEC");
+namespace my_nvtx_domains {
+    struct nvdec {
+        static constexpr char const* name = "NVDEC";
+    };
+}
+
 #include <fstream>
 #include <vector>
 #include <algorithm>
@@ -657,7 +662,7 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
 
     // Y plane
     {
-        nvtx3::scoped_range_in r(g_nvtx_nvdec, "CopyAsync(Y)");
+        nvtx3::scoped_range_in<my_nvtx_domains::nvdec> r("CopyAsync(Y)");
         CUDA_MEMCPY2D y = {};
         y.srcMemoryType = CU_MEMORYTYPE_DEVICE;
         y.srcDevice     = pDecodedFrame;
@@ -671,7 +676,7 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
 
     // UV plane
     {
-        nvtx3::scoped_range_in r(g_nvtx_nvdec, "CopyAsync(UV)");
+        nvtx3::scoped_range_in<my_nvtx_domains::nvdec> r("CopyAsync(UV)");
         CUDA_MEMCPY2D uv = {};
         uv.srcMemoryType = CU_MEMORYTYPE_DEVICE;
         uv.srcDevice     = pDecodedFrame + (size_t)srcHeightRows_Y * nDecodedPitch;
@@ -685,7 +690,7 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
 
     // Record completion event for this frame
     {
-        nvtx3::scoped_range_in r(g_nvtx_nvdec, "EventRecord(copyDone)");
+        nvtx3::scoped_range_in<my_nvtx_domains::nvdec> r("EventRecord(copyDone)");
         CUDA_CHECK_CALLBACK(cuEventRecord(fr.copyDone, s));
     }
 


### PR DESCRIPTION
Replaced direct instantiation of `nvtx3::domain`, which has a private constructor, with the modern, struct-based approach for defining NVTX domains.

This resolves the C2248 compilation error that occurred in `main.cpp` and `nvdec.cpp` when trying to create global domain objects.

The new implementation follows the recommended practice from the NVTX documentation, using a templated `scoped_range_in` with a domain type.