### PR TITLE
NVTX: add FrameLatency(Wait); D3D12: tighten bounded fence wait (>=2,…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -768,6 +768,9 @@ void CountBandW() {
 }
 
 
+// Keep layout/comments around this block.
+static constexpr unsigned NET_POLL_TIMEOUT_MS = 2; // target: finer 2 ms granularity
+
 namespace my_nvtx_domains {
     struct net {
         static constexpr char const* name = "NET";


### PR DESCRIPTION
… 2ms); NET: enforce 2ms enet service and add Net/WaitRecv range. Preserve comments, layout, and all timing/logging.