### PR TITLE
D3D12: unify Fence(Wait bounded) to >=2 and 2ms; NVDEC: verify async-…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -811,7 +811,7 @@ void ReceiveRawPacketsThread(int threadId) { // Renaming to ReceiveENetPacketsTh
         // Service ENet events with a timeout (e.g., 10ms)
         int service_result;
         {
-            nvtx3::scoped_range_in<my_nvtx_domains::net> r("Net/WaitRecv(enet_service)");
+            nvtx3::scoped_range_in<my_nvtx_domains::net> r("WaitRecv");
             service_result = enet_host_service(server_host, &event, NET_POLL_TIMEOUT_MS);
         }
 


### PR DESCRIPTION
…only copy with event-based waits; keep FrameLatency(Wait); standardize NET NVTX naming. Preserve comments, layout, and all timing/logging.

- In `window.cpp`, the bounded fence wait logic is unified to trigger on `>= 2` in-flight frames with a `2ms` timeout. The `SetEventOnCompletion` call is preserved.
- In `main.cpp`, the NVTX marker for the ENet network wait is standardized to `WaitRecv` under the `NET` domain.
- `nvdec.cpp` was reviewed and confirmed to already be using asynchronous copies with `cuMemcpy2DAsync` and event-based synchronization, so no changes were necessary.