### PR TITLE
fix(d3d12): Fix fatal DXGI_ERROR_DEVICE_REMOVED crash

### DIFF
--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -30,6 +30,9 @@ static inline uint64_t SteadyNowMs() noexcept {
 // Forward declaration from window.cpp
 extern void ClearReorderState();
 
+// Forward-declare the new function if not in a header
+extern void FlushRenderPipeline();
+
 // CUDA API error checking
 #define CUDA_RUNTIME_CHECK(call)                                                                    \
     do {                                                                                            \
@@ -263,6 +266,9 @@ void FrameDecoder::Decode(const H264Frame& frame) {
 
 bool FrameDecoder::reconfigureDecoder(CUVIDEOFORMAT* pVideoFormat) {
     DebugLog(L"Reconfiguring decoder for new video format or resolution.");
+
+    // IMPORTANT: Wait for the render thread to finish using old resources BEFORE releasing them.
+    FlushRenderPipeline();
 
     // Clean up existing decoder and resources
     releaseDecoderResources();

--- a/window.h
+++ b/window.h
@@ -10,4 +10,5 @@ void RenderFrame();
 void SendWindowSize();
 void CleanupD3DRenderResources();
 void WaitForGpu();
+void FlushRenderPipeline();
 void SnapToKnownResolution(int srcW, int srcH, int& outW, int& outH);


### PR DESCRIPTION
Fix a fatal DXGI_ERROR_DEVICE_REMOVED crash caused by a race condition during video decoder reconfiguration.

The NvdecThread was releasing D3D12 texture resources while the RenderThread was still using them, leading to a driver crash.

This change introduces a synchronization mechanism:
- A new `FlushRenderPipeline()` function is added to `window.cpp`. This function waits for the GPU to become idle and clears all in-flight frame queues.
- The `FrameDecoder::reconfigureDecoder()` function in `nvdec.cpp` now calls `FlushRenderPipeline()` before releasing any resources.

This ensures that the render pipeline is fully drained before the decoder's resources are destroyed, preventing the race condition.