### PR TITLE
feat: lock to vsync 60fps, remove double pacing, allocator ring, lowe…

### DIFF
--- a/AppShutdown.cpp
+++ b/AppShutdown.cpp
@@ -131,7 +131,6 @@ void ReleaseAllResources(const AppThreads& threads) {
         try {
             enet_deinitialize();
             FinalWSACleanup(); // Centralized WSA cleanup.
-            timeEndPeriod(1);
         } catch (...) {
             DebugLog(L"ReleaseAllResources: exception during network/timer cleanup (ignored).");
         }


### PR DESCRIPTION
…r CPU; keep logs/timers; no MonitorSharedMemory changes

This commit implements several performance improvements for the DX12 renderer.

- The application is now paced by VSync (`Present(1,0)`) instead of a manual `Sleep`-based pacer, eliminating double-pacing and reducing jitter.
- A DX12 command allocator ring (one per back buffer) is implemented to prevent CPU/GPU stalls. Fence synchronization has been updated to support this.
- Maximum frame latency is set to 1 to reduce input lag.
- The high-resolution timer (`timeBeginPeriod`) is now only activated when not in VSync mode to lower CPU usage.
- The reorder buffer wait time (`REORDER_WAIT_MS`) has been reduced from 3ms to 1ms to lower latency.
- The reorder buffer capacity (`REORDER_MAX_BUFFER`) has been reduced from 8 to 4.

All changes preserve existing logging, timing behavior, and comments as requested. No changes were made to `MonitorSharedMemory()`.