### PR TITLE
Fix: D3D12レンダリングループのフリーズを修正

### DIFF
--- a/window.cpp
+++ b/window.cpp
@@ -1231,6 +1231,9 @@ static void ResizeSwapChainOnRenderThread(int newW, int newH) {
 }
 
 void RenderFrame() {
+    if (g_frameLatencyWaitableObject != NULL) {
+        WaitForSingleObject(g_frameLatencyWaitableObject, INFINITE);
+    }
     nvtx3::scoped_range_in<d3d12_domain> frame_r("Frame");
     nvtx3::scoped_range_in<d3d12_domain> r("D3D12Present");
     // Use existing fence and queue types; keep comments and layout intact.
@@ -1286,7 +1289,7 @@ void RenderFrame() {
     const bool shouldPresent = frameWasRendered || forcePresent;
 
     if (shouldPresent) {
-        const UINT syncInterval = 1; // Lock to VSync
+        const UINT syncInterval = 0; // Lock to VSync
         const UINT presentFlags = 0; // Tearing is not allowed with VSync
         HRESULT hrPresent = S_OK;
         {


### PR DESCRIPTION
D3D12のレンダリングループにおいて、ウィンドウがフリーズする問題を修正します。

この問題は、VSyncを有効にしたブロッキングPresent呼び出しと、フェンスによる同期処理との間のデッドロックが原因である可能性が高いです。

修正内容は以下の通りです:
- Present呼び出しをノンブロッキングにするため、syncIntervalを0に変更しました。
- ループのペースを適切に制御し、CPU使用率の上昇を防ぐため、g_frameLatencyWaitableObjectでの待機処理を追加しました。これはスワップチェーンと同期するための推奨される方法です。