### PR TITLE
レンダーループにおけるウィンドウのフリーズとシャットダウンの問題を修正

### DIFF
--- a/window.cpp
+++ b/window.cpp
@@ -1283,7 +1283,7 @@ void RenderFrame() {
                 DWORD r = MsgWaitForMultipleObjectsEx(
                     1,
                     handles,
-                    INFINITE,
+                    100, // タイムアウトを100msに設定してフリーズを回避
                     QS_ALLINPUT,
                     MWMO_INPUTAVAILABLE | MWMO_ALERTABLE
                 );
@@ -1294,12 +1294,20 @@ void RenderFrame() {
                     // pump messages; preserve layout and existing logging if present
                     MSG msg;
                     while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE)) {
+                        if (msg.message == WM_QUIT) {
+                            PostQuitMessage((int)msg.wParam);
+                            return; // メインループに終了を任せるため、即時復帰
+                        }
                         TranslateMessage(&msg);
                         DispatchMessage(&msg);
                     }
                     // loop and wait again
                     continue;
-                } else {
+                } else if (r == WAIT_TIMEOUT) {
+                    // タイムアウトは想定内の動作。ループを抜けて処理を続ける
+                    break;
+                }
+                else {
                     // Unexpected; if you already have logging, reuse it.
                     break;
                 }


### PR DESCRIPTION
`RenderFrame`内のメインレンダーループには、アプリケーションのフリーズや正常なシャットダウンの失敗を引き起こす可能性のある2つの問題がありました。

1. `MsgWaitForMultipleObjectsEx`呼び出しで`INFINITE`タイムアウトが使用されていました。スワップチェーンのフレーム待機オブジェクトがシグナルされない場合（例：新しいフレームが表示されないため）、レンダースレッドが永久にブロックされ、描画が停止していました。タイムアウトを有限の値（100ms）に変更し、`WAIT_TIMEOUT`ケースを処理することで、このデッドロックを修正しました。

2. `RenderFrame`内のメッセージポンプが`WM_QUIT`メッセージを処理していませんでした。メッセージキューからメッセージを消費してしまい、メインのアプリケーションループがそれを受け取って終了することができませんでした。`WM_QUIT`をチェックし、`PostQuitMessage`で再投稿してから`RenderFrame`から即座にリターンすることで、アプリケーションが正常にシャットダウンできるように修正しました。