### PR TITLE
リサイズ時のクラッシュを修正するため、古いフレームキャッシュをクリアする

### DIFF
--- a/window.cpp
+++ b/window.cpp
@@ -356,6 +356,7 @@ void ClearReorderState()
         }
     }
     g_reorderBuffer.clear();
+    g_lastDrawnFrame = {}; // クラッシュ回避のため、キャッシュされたフレームもクリア
     g_expectedInitialized = false;
     g_expectedStreamFrame = 0;
     DebugLog(L"ClearReorderState: reorder state cleared.");


### PR DESCRIPTION
フレームキャッシュにある古いフレームを使用することにより、ウィンドウのリサイズ中にクラッシュが発生する可能性がありました。

最近追加されたフレームキャッシュ(`g_lastDrawnFrame`)は、リサイズイベント中に他のレンダリング状態がリセットされる際(`ClearReorderState`経由)にクリアされていませんでした。これにより、レンダラーが無効になった`CUevent`ハンドルを含むキャッシュ済みの`ReadyGpuFrame`オブジェクトを使用しようとし、CUDAドライバ内でクラッシュを引き起こしていました。

このコミットは、`ClearReorderState`関数に`g_lastDrawnFrame = {};`を追加することで問題を修正します。これにより、他の状態と共に古いフレームが破棄され、解放後のCUDAイベントハンドルの使用が防止されます。