### PR TITLE
fix(main): keep rendering during live-resize; preserve logs/NVTX; no …

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1296,8 +1296,13 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
         auto currentTime = std::chrono::high_resolution_clock::now();
         auto timeSinceLastRender = currentTime - lastFrameRenderTime;
 
-        // Render even while sizing; RenderFrame internally waits on the frame-latency object
-        // and pumps messages, so this won't busy-spin.
+        // Keep a tiny throttle while sizing, but do NOT skip rendering.
+        if (g_isSizing) {
+            // While user is dragging the window, avoid busy spin.
+            Sleep(1);
+        }
+
+        // Always render, even during live-resize.
         {
             nvtx3::scoped_range r("RenderFrame_Outer");
             RenderFrame(); // pacing handled by DXGI frame-latency waitable on the render side


### PR DESCRIPTION
…layout change