### PR TITLE
Fix incorrect render latency logging

### DIFF
--- a/cppcheck.txt
+++ b/cppcheck.txt
@@ -46,19 +46,19 @@ main.cpp:877:56: style: Consider using std::accumulate algorithm instead of a ra
 main.cpp:712:38: style: struct member 'net::name' is never used. [unusedStructMember]
         static constexpr char const* name = "NET";
                                      ^
-window.cpp:1452:24: style: inconclusive: Found duplicate branches for 'if' and 'else'. [duplicateBranch]
+window.cpp:1455:24: style: inconclusive: Found duplicate branches for 'if' and 'else'. [duplicateBranch]
                 } else if (r == WAIT_TIMEOUT) {
                        ^
-window.cpp:1456:17: note: Found duplicate branches for 'if' and 'else'.
+window.cpp:1459:17: note: Found duplicate branches for 'if' and 'else'.
                 else {
                 ^
-window.cpp:1452:24: note: Found duplicate branches for 'if' and 'else'.
+window.cpp:1455:24: note: Found duplicate branches for 'if' and 'else'.
                 } else if (r == WAIT_TIMEOUT) {
                        ^
-window.cpp:1263:32: style: Variable 's_lastY' can be declared as pointer to const [constVariablePointer]
+window.cpp:1266:32: style: Variable 's_lastY' can be declared as pointer to const [constVariablePointer]
         static ID3D12Resource* s_lastY = nullptr;
                                ^
-window.cpp:1264:32: style: Variable 's_lastUV' can be declared as pointer to const [constVariablePointer]
+window.cpp:1267:32: style: Variable 's_lastUV' can be declared as pointer to const [constVariablePointer]
         static ID3D12Resource* s_lastUV = nullptr;
                                ^
 window.cpp:229:52: style: struct member 'd3d12_domain::name' is never used. [unusedStructMember]
@@ -91,13 +91,10 @@ window.cpp:1233:42: style: Variable 'newFrameFromReorder.copyDone' is assigned a
 window.cpp:1238:34: style: Variable 'frameToDraw.copyDone' is assigned a value that is never used. [unreadVariable]
             frameToDraw.copyDone = nullptr;
                                  ^
-window.cpp:1245:41: style: Variable 'frameToDraw.render_start_ms' is assigned a value that is never used. [unreadVariable]
-            frameToDraw.render_start_ms = SteadyNowMs();
-                                        ^
-window.cpp:1493:30: style: Variable 'shouldPresent' is assigned a value that is never used. [unreadVariable]
+window.cpp:1496:30: style: Variable 'shouldPresent' is assigned a value that is never used. [unreadVariable]
     const bool shouldPresent = frameWasRendered || forcePresent;
                              ^
-window.cpp:1544:45: style: Variable 'renderedFrameData.nvtx_range_id' is assigned a value that is never used. [unreadVariable]
+window.cpp:1547:45: style: Variable 'renderedFrameData.nvtx_range_id' is assigned a value that is never used. [unreadVariable]
             renderedFrameData.nvtx_range_id = 0;
                                             ^
 nvdec.cpp:646:11: style: Variable 'fr' can be declared as reference to const [constVariableReference]
@@ -121,7 +118,7 @@ int getNALType(const uint8_t* data, size_t size) {
 main.cpp:1114:0: style: The function 'wWinMain' is never used. [unusedFunction]
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nCmdShow) {
 ^
-window.cpp:1616:0: style: The function 'CleanupD3DRenderResources' is never used. [unusedFunction]
+window.cpp:1619:0: style: The function 'CleanupD3DRenderResources' is never used. [unusedFunction]
 void CleanupD3DRenderResources() {
 ^
 nofile:0:0: information: Active checkers: 172/592 (use --checkers-report=<filename> to see details) [checkersReport]

--- a/window.cpp
+++ b/window.cpp
@@ -1245,6 +1245,9 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
             frameToDraw.render_start_ms = SteadyNowMs();
             // We must wait on the event from the master copy in the cache.
             std::lock_guard<std::mutex> rlock(g_reorderMutex);
+            // Propagate the render-start time to the master cached frame, so that
+            // latency stats are correct.
+            g_lastDrawnFrame.render_start_ms = frameToDraw.render_start_ms;
             if (g_lastDrawnFrame.copyDone) {
                 if (cuEventQuery(g_lastDrawnFrame.copyDone) == CUDA_ERROR_NOT_READY) {
                     nvtx3::scoped_range_in<cuda_domain> r("Wait(copyDone)");


### PR DESCRIPTION
The `RenderFrame Total (wall)` log was showing extremely large, incorrect values. This was caused by using a stale timestamp for the calculation.

The `render_start_ms` timestamp was being set on a local copy of the frame data within `PopulateCommandList` but was not propagated to the master cached frame (`g_lastDrawnFrame`). The `RenderFrame` function would then use this stale timestamp from the master copy, resulting in an incorrect latency value.

The fix ensures that the `render_start_ms` value from the local frame is copied to the master `g_lastDrawnFrame` when a new frame is processed. This provides the correct start time for the latency calculation.

- Run: cppcheck (no new issues found)