### PR TITLE
Fix: Prevent render stall on window resize

### DIFF
--- a/reports/cppcheck_report.txt
+++ b/reports/cppcheck_report.txt
@@ -1,0 +1,992 @@
+Checking AppShutdown.cpp ...
+AppShutdown.cpp:0:0: information: Too many #ifdef configurations - cppcheck only checks 12 of 38 configurations. Use --force to check all configurations. [toomanyconfigs]
+
+^
+AppShutdown.h:2:0: information: Include file: <thread> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <thread>
+^
+AppShutdown.h:3:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+AppShutdown.h:4:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>
+^
+DebugLog.h:2:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+Globals.h:3:0: information: Include file: <windows.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <windows.h>
+^
+Globals.h:4:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>
+^
+Globals.h:5:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+Globals.h:6:0: information: Include file: <thread> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <thread>
+^
+Globals.h:7:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+Globals.h:8:0: information: Include file: <utility> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <utility>
+^
+Globals.h:9:0: information: Include file: <cstdint> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdint>
+^
+directx/d3d12.h:26:0: information: Include file: "rpc.h" not found. [missingInclude]
+#include "rpc.h"
+^
+directx/d3d12.h:27:0: information: Include file: "rpcndr.h" not found. [missingInclude]
+#include "rpcndr.h"
+^
+directx/d3d12.h:34:0: information: Include file: "windows.h" not found. [missingInclude]
+#include "windows.h"
+^
+directx/d3d12.h:35:0: information: Include file: "ole2.h" not found. [missingInclude]
+#include "ole2.h"
+^
+directx/d3d12.h:602:0: information: Include file: "oaidl.h" not found. [missingInclude]
+#include "oaidl.h"
+^
+directx/d3d12.h:603:0: information: Include file: "ocidl.h" not found. [missingInclude]
+#include "ocidl.h"
+^
+directx/d3dcommon.h:27:0: information: Include file: "rpc.h" not found. [missingInclude]
+#include "rpc.h"
+^
+directx/d3dcommon.h:28:0: information: Include file: "rpcndr.h" not found. [missingInclude]
+#include "rpcndr.h"
+^
+directx/d3dcommon.h:35:0: information: Include file: "windows.h" not found. [missingInclude]
+#include "windows.h"
+^
+directx/d3dcommon.h:36:0: information: Include file: "ole2.h" not found. [missingInclude]
+#include "ole2.h"
+^
+directx/d3dcommon.h:71:0: information: Include file: "oaidl.h" not found. [missingInclude]
+#include "oaidl.h"
+^
+directx/d3dcommon.h:72:0: information: Include file: "ocidl.h" not found. [missingInclude]
+#include "ocidl.h"
+^
+directx/d3d12.h:616:0: information: Include file: <winapifamily.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <winapifamily.h>
+^
+Globals.h:11:0: information: Include file: <wrl/client.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <wrl/client.h>
+^
+Globals.h:12:0: information: Include file: <deque> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <deque>
+^
+Globals.h:13:0: information: Include file: <mutex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mutex>
+^
+Globals.h:14:0: information: Include file: <sstream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <sstream>
+^
+Globals.h:15:0: information: Include file: <iostream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <iostream>
+^
+Globals.h:16:0: information: Include file: <iomanip> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <iomanip>
+^
+Globals.h:17:0: information: Include file: <condition_variable> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <condition_variable>
+^
+Globals.h:18:0: information: Include file: <unordered_map> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <unordered_map>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:67:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>  // Requires C++11. Sorry VS2010.
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:68:0: information: Include file: <cassert> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cassert>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:70:0: information: Include file: <cstddef> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstddef>              // for max_align_t
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:71:0: information: Include file: <cstdint> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdint>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:72:0: information: Include file: <cstdlib> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdlib>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:73:0: information: Include file: <type_traits> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <type_traits>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:74:0: information: Include file: <algorithm> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <algorithm>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:75:0: information: Include file: <utility> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <utility>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:76:0: information: Include file: <limits> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <limits>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:77:0: information: Include file: <climits> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <climits>  // for CHAR_BIT
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:78:0: information: Include file: <array> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <array>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:79:0: information: Include file: <thread> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <thread>  // partly for __WINPTHREADS_VERSION if on MinGW-w64 w/ POSIX threading
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:80:0: information: Include file: <mutex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mutex>        // used for thread exit synchronization
+^
+Globals.h:20:0: information: Include file: <nvtx3/nvtx3.hpp> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <nvtx3/nvtx3.hpp>
+^
+Globals.h:23:0: information: Include file: <cuda.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cuda.h>
+^
+nvdec.h:3:0: information: Include file: <nvtx3/nvtx3.hpp> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <nvtx3/nvtx3.hpp>
+^
+nvdec.h:5:0: information: Include file: <wrl/client.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <wrl/client.h>
+^
+nvdec.h:6:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+nvdec.h:7:0: information: Include file: <memory> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <memory>
+^
+nvdec.h:8:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+nvdec.h:9:0: information: Include file: <cstdint> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdint>
+^
+nvdec.h:10:0: information: Include file: <unordered_map> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <unordered_map>
+^
+nvdec.h:11:0: information: Include file: <mutex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mutex>
+^
+nvdec.h:14:0: information: Include file: <cuda.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cuda.h>
+^
+nvdec.h:15:0: information: Include file: <cuda_runtime_api.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cuda_runtime_api.h>
+^
+nvdec.h:18:0: information: Include file: "nvcuvid.h" not found. [missingInclude]
+#include "nvcuvid.h"
+^
+nvdec.h:19:0: information: Include file: "cuviddec.h" not found. [missingInclude]
+#include "cuviddec.h"
+^
+window.h:1:0: information: Include file: <windows.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <windows.h>
+^
+window.h:2:0: information: Include file: <wrl/client.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <wrl/client.h>
+^
+window.h:3:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>
+^
+AppShutdown.cpp:7:0: information: Include file: <Windows.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <Windows.h>
+^
+AppShutdown.cpp:8:0: information: Include file: <winsock2.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <winsock2.h>
+^
+AppShutdown.cpp:9:0: information: Include file: <ws2tcpip.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <ws2tcpip.h>
+^
+AppShutdown.cpp:10:0: information: Include file: <enet/enet.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <enet/enet.h>
+^
+AppShutdown.cpp:11:0: information: Include file: <cuda.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cuda.h>
+^
+AppShutdown.cpp:12:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>
+^
+AppShutdown.cpp:13:0: information: Include file: <exception> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <exception>
+^
+AppShutdown.cpp:14:0: information: Include file: <mutex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mutex>
+^
+AppShutdown.cpp:15:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+AppShutdown.cpp:16:0: information: Include file: <mmsystem.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mmsystem.h>
+^
+Checking AppShutdown.cpp: CINTERFACE;_MSC_VER;_WIN32;__RPCNDR_H_VERSION__...
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1300:14: performance: inconclusive: Technically the member function 'ConcurrentQueue < H264Frame , ConcurrentQueueDefaultTraits >::try_dequeue_from_producer' can be static (but you may consider moving to unnamed namespace). [functionStatic]
+ inline bool try_dequeue_from_producer(producer_token_t const& producer, U& item)
+             ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1313:16: performance: inconclusive: Technically the member function 'ConcurrentQueue < H264Frame , ConcurrentQueueDefaultTraits >::try_dequeue_bulk_from_producer' can be static (but you may consider moving to unnamed namespace). [functionStatic]
+ inline size_t try_dequeue_bulk_from_producer(producer_token_t const& producer, It itemFirst, size_t max)
+               ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1955:8: warning: The struct 'ExplicitProducer' defines member function with name 'dequeue' also defined in its parent struct 'ProducerBase'. [duplInheritedMember]
+  bool dequeue(U& element)
+       ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1714:15: note: Parent function 'ProducerBase::dequeue'
+  inline bool dequeue(U& element)
+              ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1955:8: note: Derived function 'ExplicitProducer::dequeue'
+  bool dequeue(U& element)
+       ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2248:10: warning: The struct 'ExplicitProducer' defines member function with name 'dequeue_bulk' also defined in its parent struct 'ProducerBase'. [duplInheritedMember]
+  size_t dequeue_bulk(It& itemFirst, size_t max)
+         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1725:17: note: Parent function 'ProducerBase::dequeue_bulk'
+  inline size_t dequeue_bulk(It& itemFirst, size_t max)
+                ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2248:10: note: Derived function 'ExplicitProducer::dequeue_bulk'
+  size_t dequeue_bulk(It& itemFirst, size_t max)
+         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2551:8: warning: The struct 'ImplicitProducer' defines member function with name 'dequeue' also defined in its parent struct 'ProducerBase'. [duplInheritedMember]
+  bool dequeue(U& element)
+       ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1714:15: note: Parent function 'ProducerBase::dequeue'
+  inline bool dequeue(U& element)
+              ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2551:8: note: Derived function 'ImplicitProducer::dequeue'
+  bool dequeue(U& element)
+       ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2780:10: warning: The struct 'ImplicitProducer' defines member function with name 'dequeue_bulk' also defined in its parent struct 'ProducerBase'. [duplInheritedMember]
+  size_t dequeue_bulk(It& itemFirst, size_t max)
+         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1725:17: note: Parent function 'ProducerBase::dequeue_bulk'
+  inline size_t dequeue_bulk(It& itemFirst, size_t max)
+                ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2780:10: note: Derived function 'ImplicitProducer::dequeue_bulk'
+  size_t dequeue_bulk(It& itemFirst, size_t max)
+         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2423:3: style: Struct 'ImplicitProducer' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
+  ImplicitProducer(ConcurrentQueue* parent_) :
+  ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1453:3: style: Struct 'FreeList < Block >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
+  FreeList(FreeList&& other) : freeListHead(other.freeListHead.load(std::memory_order_relaxed)) { other.freeListHead.store(nullptr, std::memory_order_relaxed); }
+  ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1456:3: style: Struct 'FreeList < Block >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
+  FreeList(FreeList const&) MOODYCAMEL_DELETE_FUNCTION;
+  ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2182:6: style: Expression is always false because 'else if' condition matches previous condition at line 2176. [multiCondition]
+     MOODYCAMEL_TRY {
+     ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2721:6: style: Expression is always false because 'else if' condition matches previous condition at line 2715. [multiCondition]
+     MOODYCAMEL_TRY {
+     ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2263:22: style: Condition 'actualCount<desiredCount' is always false [knownConditionTrueFalse]
+     if (actualCount < desiredCount) {
+                     ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2262:18: note: actualCount is assigned 'desiredCount<actualCount?desiredCount:actualCount' here.
+     actualCount = desiredCount < actualCount ? desiredCount : actualCount;
+                 ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2263:22: note: Condition 'actualCount<desiredCount' is always false
+     if (actualCount < desiredCount) {
+                     ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2795:22: style: Condition 'actualCount<desiredCount' is always false [knownConditionTrueFalse]
+     if (actualCount < desiredCount) {
+                     ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2794:18: note: actualCount is assigned 'desiredCount<actualCount?desiredCount:actualCount' here.
+     actualCount = desiredCount < actualCount ? desiredCount : actualCount;
+                 ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2795:22: note: Condition 'actualCount<desiredCount' is always false
+     if (actualCount < desiredCount) {
+                     ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3586:8: style: Condition '!raw' is always false [knownConditionTrueFalse]
+   if (!raw)
+       ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3585:16: note: Assignment 'raw=(ConcurrentQueueDefaultTraits::malloc)(size+alignment-1+sizeof(void*))', assigned value is greater than 7
+   void* raw = (Traits::malloc)(size + alignment - 1 + sizeof(void*));
+               ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3586:8: note: Condition '!raw' is always false
+   if (!raw)
+       ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3370:6: style: 'continue' is redundant since it is the last statement in a loop. [redundantContinue]
+     continue;
+     ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3380:6: style: 'continue' is redundant since it is the last statement in a loop. [redundantContinue]
+     continue;
+     ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3702:58: style: inconclusive: Function 'ConsumerToken' argument 1 names different: declaration 'q' definition 'queue'. [funcArgNamesDifferent]
+ConsumerToken::ConsumerToken(ConcurrentQueue<T, Traits>& queue)
+                                                         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:719:53: note: Function 'ConsumerToken' argument 1 names different: declaration 'q' definition 'queue'.
+ explicit ConsumerToken(ConcurrentQueue<T, Traits>& q);
+                                                    ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3702:58: note: Function 'ConsumerToken' argument 1 names different: declaration 'q' definition 'queue'.
+ConsumerToken::ConsumerToken(ConcurrentQueue<T, Traits>& queue)
+                                                         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3710:66: style: inconclusive: Function 'ConsumerToken' argument 1 names different: declaration 'q' definition 'queue'. [funcArgNamesDifferent]
+ConsumerToken::ConsumerToken(BlockingConcurrentQueue<T, Traits>& queue)
+                                                                 ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:722:61: note: Function 'ConsumerToken' argument 1 names different: declaration 'q' definition 'queue'.
+ explicit ConsumerToken(BlockingConcurrentQueue<T, Traits>& q);
+                                                            ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3710:66: note: Function 'ConsumerToken' argument 1 names different: declaration 'q' definition 'queue'.
+ConsumerToken::ConsumerToken(BlockingConcurrentQueue<T, Traits>& queue)
+                                                                 ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2165:9: style: Variable 'endBlock' can be declared as pointer to const [constVariablePointer]
+   auto endBlock = this->tailBlock;
+        ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2201:12: style: Variable 'lastBlockEnqueued' can be declared as pointer to const [constVariablePointer]
+      auto lastBlockEnqueued = this->tailBlock;
+           ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2640:9: style: Variable 'endBlock' can be declared as pointer to const [constVariablePointer]
+   auto endBlock = this->tailBlock;
+        ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2730:12: style: Variable 'lastBlockEnqueued' can be declared as pointer to const [constVariablePointer]
+      auto lastBlockEnqueued = this->tailBlock;
+           ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2039:7: warning: inconclusive: Access of moved variable 'el'. [accessMoved]
+      el.~T(); // NOLINT
+      ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2038:17: note: Calling std::move(el)
+      element = std::move(el); // NOLINT
+                ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2039:7: note: Access of moved variable 'el'.
+      el.~T(); // NOLINT
+      ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2291:9: warning: inconclusive: Access of moved variable 'el'. [accessMoved]
+        el.~T();
+        ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2290:24: note: Calling std::move(el)
+        *itemFirst++ = std::move(el);
+                       ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2291:9: note: Access of moved variable 'el'.
+        el.~T();
+        ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2301:10: warning: inconclusive: Access of moved variable 'el'. [accessMoved]
+         el.~T();
+         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2299:23: note: Calling std::move(el)
+         *itemFirst = std::move(el);
+                      ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2301:10: note: Access of moved variable 'el'.
+         el.~T();
+         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2597:7: warning: inconclusive: Access of moved variable 'el'. [accessMoved]
+      el.~T(); // NOLINT
+      ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2596:17: note: Calling std::move(el)
+      element = std::move(el); // NOLINT
+                ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2597:7: note: Access of moved variable 'el'.
+      el.~T(); // NOLINT
+      ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2818:9: warning: inconclusive: Access of moved variable 'el'. [accessMoved]
+        el.~T();
+        ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2817:24: note: Calling std::move(el)
+        *itemFirst++ = std::move(el);
+                       ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2818:9: note: Access of moved variable 'el'.
+        el.~T();
+        ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2828:10: warning: inconclusive: Access of moved variable 'el'. [accessMoved]
+         el.~T();
+         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2826:23: note: Calling std::move(el)
+         *itemFirst = std::move(el);
+                      ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2828:10: note: Access of moved variable 'el'.
+         el.~T();
+         ^
+Checking AppShutdown.cpp: CINTERFACE;__RPCNDR_H_VERSION__...
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1915:31: warning: Redundant code: Found a statement that begins with NULL constant. [constStatement]
+    MOODYCAMEL_CONSTEXPR_IF (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
+                              ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1941:31: warning: Redundant code: Found a statement that begins with NULL constant. [constStatement]
+    MOODYCAMEL_CONSTEXPR_IF (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
+                              ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2157:30: warning: Redundant code: Found a statement that begins with NULL constant. [constStatement]
+    MOODYCAMEL_CONSTEXPR_IF (MOODYCAMEL_NOEXCEPT_CTOR(T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
+                             ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2176:30: warning: Redundant code: Found a statement that begins with NULL constant. [constStatement]
+    MOODYCAMEL_CONSTEXPR_IF (MOODYCAMEL_NOEXCEPT_CTOR(T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
+                             ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2238:30: warning: Redundant code: Found a statement that begins with NULL constant. [constStatement]
+   MOODYCAMEL_CONSTEXPR_IF (!MOODYCAMEL_NOEXCEPT_CTOR(T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
+                             ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2519:31: warning: Redundant code: Found a statement that begins with NULL constant. [constStatement]
+    MOODYCAMEL_CONSTEXPR_IF (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
+                              ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2537:31: warning: Redundant code: Found a statement that begins with NULL constant. [constStatement]
+    MOODYCAMEL_CONSTEXPR_IF (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
+                              ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2715:30: warning: Redundant code: Found a statement that begins with NULL constant. [constStatement]
+    MOODYCAMEL_CONSTEXPR_IF (MOODYCAMEL_NOEXCEPT_CTOR(T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
+                             ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2035:27: warning: Access of moved variable 'el'. [accessMoved]
+      element = std::move(el); // NOLINT
+                          ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2021:11: note: Calling std::move(el)
+     if (!MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
+          ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2035:27: note: Access of moved variable 'el'.
+      element = std::move(el); // NOLINT
+                          ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2593:27: warning: Access of moved variable 'el'. [accessMoved]
+      element = std::move(el); // NOLINT
+                          ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2571:11: note: Calling std::move(el)
+     if (!MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
+          ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:2593:27: note: Access of moved variable 'el'.
+      element = std::move(el); // NOLINT
+                          ^
+Checking AppShutdown.cpp: COBJMACROS;_WIN32;__RPCNDR_H_VERSION__...
+Checking AppShutdown.cpp: COBJMACROS;__RPCNDR_H_VERSION__...
+Checking AppShutdown.cpp: D3D12_IGNORE_SDK_LAYERS;__RPCNDR_H_VERSION__...
+Checking AppShutdown.cpp: MCDBGQ_NOLOCKFREE_FREELIST;__RPCNDR_H_VERSION__...
+Checking AppShutdown.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX;__RPCNDR_H_VERSION__...
+Checking AppShutdown.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH;__RPCNDR_H_VERSION__...
+Checking AppShutdown.cpp: MCDBGQ_TRACKMEM;__RPCNDR_H_VERSION__...
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3183:13: style: Local variable 'block' shadows outer variable [shadowVariable]
+       auto block = tailBlock;
+            ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3142:10: note: Shadowed declaration
+    auto block = q->freeList.head_unsafe();
+         ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3183:13: note: Shadow variable
+       auto block = tailBlock;
+            ^
+Checking AppShutdown.cpp: MCDBGQ_USEDEBUGFREELIST;__RPCNDR_H_VERSION__...
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:58:0: information: Include file: "relacy/relacy_std.hpp" not found. [missingInclude]
+#include "relacy/relacy_std.hpp"
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:59:0: information: Include file: "relacy_shims.h" not found. [missingInclude]
+#include "relacy_shims.h"
+^
+Checking AppShutdown.cpp: MCDBGQ_USE_RELACY;__GNUC__;__INTEL_COMPILER;__RPCNDR_H_VERSION__...
+Checking AppShutdown.cpp: MCDBGQ_USE_RELACY;__RPCNDR_H_VERSION__...
+1/7 files checked 2% done
+Checking DebugLog.cpp ...
+DebugLog.cpp:0:0: information: Too many #ifdef configurations - cppcheck only checks 12 of 25 configurations. Use --force to check all configurations. [toomanyconfigs]
+
+^
+DebugLog.cpp:4:0: information: Include file: <windows.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <windows.h>
+^
+DebugLog.cpp:5:0: information: Include file: <processthreadsapi.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <processthreadsapi.h>
+^
+DebugLog.cpp:6:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>
+^
+DebugLog.cpp:7:0: information: Include file: <chrono> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <chrono>
+^
+DebugLog.cpp:8:0: information: Include file: <condition_variable> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <condition_variable>
+^
+DebugLog.cpp:9:0: information: Include file: <deque> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <deque>
+^
+DebugLog.cpp:10:0: information: Include file: <fstream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <fstream>
+^
+DebugLog.cpp:11:0: information: Include file: <mutex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mutex>
+^
+DebugLog.cpp:12:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+DebugLog.cpp:13:0: information: Include file: <thread> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <thread>
+^
+DebugLog.cpp:14:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+DebugLog.cpp:15:0: information: Include file: <cstdio> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdio>
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1300:14: performance: inconclusive: Technically the member function 'ConcurrentQueue < LogMsg , ConcurrentQueueDefaultTraits >::try_dequeue_from_producer' can be static (but you may consider moving to unnamed namespace). [functionStatic]
+ inline bool try_dequeue_from_producer(producer_token_t const& producer, U& item)
+             ^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1313:16: performance: inconclusive: Technically the member function 'ConcurrentQueue < LogMsg , ConcurrentQueueDefaultTraits >::try_dequeue_bulk_from_producer' can be static (but you may consider moving to unnamed namespace). [functionStatic]
+ inline size_t try_dequeue_bulk_from_producer(producer_token_t const& producer, It itemFirst, size_t max)
+               ^
+Checking DebugLog.cpp: MCDBGQ_NOLOCKFREE_FREELIST...
+Checking DebugLog.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX...
+Checking DebugLog.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH...
+Checking DebugLog.cpp: MCDBGQ_TRACKMEM...
+Checking DebugLog.cpp: MCDBGQ_USEDEBUGFREELIST...
+Checking DebugLog.cpp: MCDBGQ_USE_RELACY...
+Checking DebugLog.cpp: MCDBGQ_USE_RELACY;__GNUC__;__INTEL_COMPILER...
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:54:0: information: Include file: "TargetConditionals.h" not found. [missingInclude]
+#include "TargetConditionals.h"
+^
+Checking DebugLog.cpp: MOODYCAMEL_NO_THREAD_LOCAL;_M_ARM;__APPLE__;__MVS__;__aarch64__;__arm__...
+Checking DebugLog.cpp: MOODYCAMEL_NO_THREAD_LOCAL;_M_ARM;__APPLE__;__MVS__;__aarch64__;__arm__;__APPLE__...
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:287:0: information: Include file: "internal/concurrentqueue_internal_debug.h" not found. [missingInclude]
+#include "internal/concurrentqueue_internal_debug.h"
+^
+Checking DebugLog.cpp: MOODYCAMEL_QUEUE_INTERNAL_DEBUG...
+Checking DebugLog.cpp: TARGET_OS_IPHONE=0;_MSC_VER;_M_ARM;__APPLE__;__GNUC__;__MINGW32__;__MINGW64__;__MVS__;__WINPTHREADS_VERSION;__aarch64__;__arm__...
+2/7 files checked 6% done
+Checking Globals.cpp ...
+Globals.cpp:0:0: information: Too many #ifdef configurations - cppcheck only checks 12 of 38 configurations. Use --force to check all configurations. [toomanyconfigs]
+
+^
+Globals.cpp:1:0: information: Include file: <Windows.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <Windows.h>
+^
+Globals.cpp:2:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>
+^
+Globals.cpp:3:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+Globals.cpp:4:0: information: Include file: <mutex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mutex>
+^
+Globals.cpp:6:0: information: Include file: "Nvdec.h" not found. [missingInclude]
+#include "Nvdec.h"
+^
+main.h:2:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+Checking Globals.cpp: CINTERFACE;_MSC_VER;_WIN32;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: CINTERFACE;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: COBJMACROS;_WIN32;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: COBJMACROS;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: D3D12_IGNORE_SDK_LAYERS;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: MCDBGQ_NOLOCKFREE_FREELIST;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: MCDBGQ_TRACKMEM;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: MCDBGQ_USEDEBUGFREELIST;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: MCDBGQ_USE_RELACY;__GNUC__;__INTEL_COMPILER;__RPCNDR_H_VERSION__...
+Checking Globals.cpp: MCDBGQ_USE_RELACY;__RPCNDR_H_VERSION__...
+3/7 files checked 7% done
+Checking ReedSolomon.cpp ...
+ReedSolomon.cpp:0:0: information: Too many #ifdef configurations - cppcheck only checks 12 of 38 configurations. Use --force to check all configurations. [toomanyconfigs]
+
+^
+ReedSolomon.cpp:3:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+ReedSolomon.cpp:4:0: information: Include file: <map> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <map>     // ※ std::map を使用するためにインクルード
+^
+ReedSolomon.cpp:5:0: information: Include file: <cstdint> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdint>
+^
+ReedSolomon.cpp:6:0: information: Include file: <cstring> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstring> // for memcpy
+^
+ReedSolomon.cpp:8:0: information: Include file: <gf_complete.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <gf_complete.h>
+^
+ReedSolomon.cpp:9:0: information: Include file: <jerasure.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <jerasure.h>
+^
+ReedSolomon.h:1:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+ReedSolomon.h:2:0: information: Include file: <cstdint> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdint>
+^
+ReedSolomon.h:3:0: information: Include file: <map> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <map>     // ※ std::map を使用するためにインクルード
+^
+Checking ReedSolomon.cpp: CINTERFACE;_MSC_VER;_WIN32;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: CINTERFACE;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: COBJMACROS;_WIN32;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: COBJMACROS;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: D3D12_IGNORE_SDK_LAYERS;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: MCDBGQ_NOLOCKFREE_FREELIST;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: MCDBGQ_TRACKMEM;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: MCDBGQ_USEDEBUGFREELIST;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: MCDBGQ_USE_RELACY;__GNUC__;__INTEL_COMPILER;__RPCNDR_H_VERSION__...
+Checking ReedSolomon.cpp: MCDBGQ_USE_RELACY;__RPCNDR_H_VERSION__...
+4/7 files checked 10% done
+Checking main.cpp ...
+main.cpp:0:0: information: Too many #ifdef configurations - cppcheck only checks 12 of 44 configurations. Use --force to check all configurations. [toomanyconfigs]
+
+^
+main.cpp:9:0: information: Include file: <winsock2.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <winsock2.h>
+^
+main.cpp:10:0: information: Include file: <cstdint> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdint> // For uint64_t
+^
+main.cpp:11:0: information: Include file: <chrono> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <chrono>
+^
+main.cpp:13:0: information: Include file: <ws2tcpip.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <ws2tcpip.h>
+^
+main.cpp:14:0: information: Include file: <mswsock.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mswsock.h> // Required for WSARecvMsg and WSASendMsg
+^
+main.cpp:15:0: information: Include file: <windows.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <windows.h>
+^
+main.cpp:16:0: information: Include file: <mmsystem.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mmsystem.h>
+^
+main.cpp:17:0: information: Include file: <thread> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <thread>
+^
+main.cpp:18:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>
+^
+main.cpp:19:0: information: Include file: <algorithm> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <algorithm>
+^
+main.cpp:20:0: information: Include file: <fstream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <fstream>
+^
+main.cpp:21:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+main.cpp:22:0: information: Include file: <mutex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mutex>
+^
+main.cpp:23:0: information: Include file: <ctime> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <ctime>
+^
+main.cpp:25:0: information: Include file: <filesystem> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <filesystem>
+^
+main.cpp:26:0: information: Include file: <regex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <regex>
+^
+main.cpp:27:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+main.cpp:28:0: information: Include file: <iostream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <iostream>
+^
+main.cpp:29:0: information: Include file: <iomanip> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <iomanip>
+^
+main.cpp:30:0: information: Include file: <cstdint> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstdint>
+^
+main.cpp:31:0: information: Include file: <cstring> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstring>
+^
+main.cpp:32:0: information: Include file: <map> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <map>
+^
+main.cpp:33:0: information: Include file: <queue> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <queue>
+^
+main.cpp:34:0: information: Include file: <condition_variable> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <condition_variable>
+^
+main.cpp:39:0: information: Include file: <gf_complete.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <gf_complete.h>
+^
+main.cpp:40:0: information: Include file: <jerasure.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <jerasure.h>
+^
+main.cpp:41:0: information: Include file: <reed_sol.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <reed_sol.h>
+^
+main.cpp:42:0: information: Include file: <cauchy.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cauchy.h>
+^
+main.cpp:43:0: information: Include file: <sstream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <sstream>
+^
+main.cpp:45:0: information: Include file: <enet/enet.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <enet/enet.h>
+^
+main.cpp:46:0: information: Include file: <nvtx3/nvtx3.hpp> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <nvtx3/nvtx3.hpp>
+^
+main.cpp:50:0: information: Include file: <cuda.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cuda.h>
+^
+main.cpp:51:0: information: Include file: <cuda_runtime_api.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cuda_runtime_api.h>
+^
+directx/d3dx12_core.h:14:0: information: Include file: <string.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string.h>
+^
+directx/d3dx12_state_object.h:31:0: information: Include file: <list> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <list>
+^
+directx/d3dx12_state_object.h:32:0: information: Include file: <forward_list> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <forward_list>
+^
+directx/d3dx12_state_object.h:33:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+directx/d3dx12_state_object.h:34:0: information: Include file: <memory> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <memory>
+^
+directx/d3dx12_state_object.h:35:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+directx/d3dx12_state_object.h:36:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+directx/d3dx12_state_object.h:38:0: information: Include file: <wrl/client.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <wrl/client.h>
+^
+directx/d3dx12_check_feature_support.h:20:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+main.cpp:184:0: information: Include file: <dxgi1_6.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <dxgi1_6.h>
+^
+main.cpp:186:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+main.cpp:187:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+main.cpp:321:0: information: Include file: <ShellScalingApi.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <ShellScalingApi.h>
+^
+Checking main.cpp: CINTERFACE;_MSC_VER;_WIN32;__RPCNDR_H_VERSION__...
+directx/d3dx12_resource_helpers.h:75:5: error: There is an unknown macro here somewhere. Configuration is required. If _In_range_ is a macro then please configure it. [unknownMacro]
+    _In_range_(0,D3D12_REQ_SUBRESOURCES) UINT FirstSubresource,
+    ^
+Checking main.cpp: CINTERFACE;__RPCNDR_H_VERSION__...
+Checking main.cpp: COBJMACROS;_WIN32;__RPCNDR_H_VERSION__...
+Checking main.cpp: COBJMACROS;__RPCNDR_H_VERSION__...
+Checking main.cpp: D3D12_IGNORE_SDK_LAYERS;__RPCNDR_H_VERSION__...
+Checking main.cpp: MCDBGQ_NOLOCKFREE_FREELIST;__RPCNDR_H_VERSION__...
+Checking main.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX;__RPCNDR_H_VERSION__...
+Checking main.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH;__RPCNDR_H_VERSION__...
+Checking main.cpp: MCDBGQ_TRACKMEM;__RPCNDR_H_VERSION__...
+Checking main.cpp: MCDBGQ_USEDEBUGFREELIST;__RPCNDR_H_VERSION__...
+Checking main.cpp: MCDBGQ_USE_RELACY;__GNUC__;__INTEL_COMPILER;__RPCNDR_H_VERSION__...
+Checking main.cpp: MCDBGQ_USE_RELACY;__RPCNDR_H_VERSION__...
+5/7 files checked 42% done
+Checking nvdec.cpp ...
+nvdec.cpp:0:0: information: Too many #ifdef configurations - cppcheck only checks 12 of 38 configurations. Use --force to check all configurations. [toomanyconfigs]
+
+^
+nvdec.cpp:3:0: information: Include file: <nvtx3/nvtx3.hpp> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <nvtx3/nvtx3.hpp>
+^
+nvdec.cpp:4:0: information: Include file: <stdexcept> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <stdexcept>
+^
+nvdec.cpp:12:0: information: Include file: <fstream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <fstream>
+^
+nvdec.cpp:13:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+nvdec.cpp:14:0: information: Include file: <algorithm> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <algorithm>
+^
+nvdec.cpp:15:0: information: Include file: <sstream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <sstream>
+^
+nvdec.cpp:17:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic>
+^
+nvdec.cpp:18:0: information: Include file: <chrono> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <chrono>
+^
+Checking nvdec.cpp: CINTERFACE;_MSC_VER;_WIN32;__RPCNDR_H_VERSION__...
+nvdec.cpp:636:11: style: Variable 'fr' can be declared as reference to const [constVariableReference]
+    auto& fr = self->m_frameResources[pDispInfo->picture_index];
+          ^
+nvdec.cpp:383:49: style: Parameter 'pVideoFormat' can be declared as pointer to const [constParameterPointer]
+bool FrameDecoder::createDecoder(CUVIDEOFORMAT* pVideoFormat) {
+                                                ^
+nvdec.cpp:8:38: style: struct member 'nvdec::name' is never used. [unusedStructMember]
+        static constexpr char const* name = "NVDEC";
+                                     ^
+Checking nvdec.cpp: CINTERFACE;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: COBJMACROS;_WIN32;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: COBJMACROS;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: D3D12_IGNORE_SDK_LAYERS;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: MCDBGQ_NOLOCKFREE_FREELIST;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: MCDBGQ_TRACKMEM;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: MCDBGQ_USEDEBUGFREELIST;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: MCDBGQ_USE_RELACY;__GNUC__;__INTEL_COMPILER;__RPCNDR_H_VERSION__...
+Checking nvdec.cpp: MCDBGQ_USE_RELACY;__RPCNDR_H_VERSION__...
+6/7 files checked 61% done
+Checking window.cpp ...
+window.cpp:0:0: information: Too many #ifdef configurations - cppcheck only checks 12 of 43 configurations. Use --force to check all configurations. [toomanyconfigs]
+
+^
+window.cpp:1:0: information: Include file: <nvtx3/nvtx3.hpp> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <nvtx3/nvtx3.hpp>
+^
+window.cpp:2:0: information: Include file: <d3dcompiler.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <d3dcompiler.h> // For shader compilation
+^
+window.cpp:3:0: information: Include file: <DirectXColors.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <DirectXColors.h> // For DirectX::Colors
+^
+window.cpp:4:0: information: Include file: <windows.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <windows.h>
+^
+window.cpp:7:0: information: Include file: <wrl/client.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <wrl/client.h>
+^
+window.cpp:8:0: information: Include file: <dxgi1_6.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <dxgi1_6.h> // For IDXGIFactory6 and CreateSwapChainForHwnd
+^
+window.cpp:9:0: information: Include file: <cmath> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cmath>
+^
+window.cpp:10:0: information: Include file: <winsock2.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <winsock2.h>
+^
+window.cpp:11:0: information: Include file: <ws2tcpip.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <ws2tcpip.h>
+^
+window.cpp:12:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector>
+^
+window.cpp:13:0: information: Include file: <string> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <string>
+^
+window.cpp:14:0: information: Include file: <iostream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <iostream>
+^
+window.cpp:15:0: information: Include file: <stdexcept> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <stdexcept>
+^
+window.cpp:16:0: information: Include file: <cstring> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cstring>
+^
+window.cpp:19:0: information: Include file: <algorithm> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <algorithm> // For std::min, std::abs
+^
+window.cpp:20:0: information: Include file: <vector> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <vector> // For std::vector
+^
+window.cpp:21:0: information: Include file: <deque> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <deque>  // For std::deque (used by Globals.h)
+^
+window.cpp:22:0: information: Include file: <mutex> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <mutex>  // For std::mutex (used by Globals.h)
+^
+window.cpp:23:0: information: Include file: <condition_variable> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <condition_variable> // For std::condition_variable (used by Globals.h)
+^
+window.cpp:24:0: information: Include file: <atomic> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <atomic> // For std::atomic (used by Globals.h)
+^
+window.cpp:25:0: information: Include file: <sstream> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <sstream>      // Required for std::wstringstream (for PointerToWString)
+^
+window.cpp:26:0: information: Include file: <iomanip> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <iomanip>      // Required for std::hex (for PointerToWString)
+^
+window.cpp:27:0: information: Include file: <chrono> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <chrono> // For time measurement
+^
+window.cpp:28:0: information: Include file: <map> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <map>
+^
+window.cpp:29:0: information: Include file: <queue> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <queue>
+^
+window.cpp:39:0: information: Include file: <cuda.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cuda.h>
+^
+window.cpp:40:0: information: Include file: <cuda_runtime_api.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <cuda_runtime_api.h>
+^
+window.cpp:46:0: information: Include file: <ShellScalingApi.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <ShellScalingApi.h> // AdjustWindowRectExForDpi 等
+^
+window.cpp:143:0: information: Include file: <windows.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <windows.h>
+^
+window.cpp:144:0: information: Include file: <dwmapi.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
+#include <dwmapi.h>
+^
+Checking window.cpp: CINTERFACE;_MSC_VER;_WIN32;__RPCNDR_H_VERSION__...
+Checking window.cpp: CINTERFACE;__RPCNDR_H_VERSION__...
+Checking window.cpp: COBJMACROS;_WIN32;__RPCNDR_H_VERSION__...
+Checking window.cpp: COBJMACROS;__RPCNDR_H_VERSION__...
+Checking window.cpp: D3D12_IGNORE_SDK_LAYERS;__RPCNDR_H_VERSION__...
+Checking window.cpp: MCDBGQ_NOLOCKFREE_FREELIST;__RPCNDR_H_VERSION__...
+Checking window.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX;__RPCNDR_H_VERSION__...
+Checking window.cpp: MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH;__RPCNDR_H_VERSION__...
+Checking window.cpp: MCDBGQ_TRACKMEM;__RPCNDR_H_VERSION__...
+Checking window.cpp: MCDBGQ_USEDEBUGFREELIST;__RPCNDR_H_VERSION__...
+Checking window.cpp: MCDBGQ_USE_RELACY;__GNUC__;__INTEL_COMPILER;__RPCNDR_H_VERSION__...
+Checking window.cpp: MCDBGQ_USE_RELACY;__RPCNDR_H_VERSION__...
+7/7 files checked 100% done
+AppShutdown.cpp:73:0: style: The function 'RequestShutdown' is never used. [unusedFunction]
+void RequestShutdown(std::atomic<bool>* appRunningPtr) {
+^
+AppShutdown.cpp:96:0: style: The function 'ReleaseAllResources' is never used. [unusedFunction]
+void ReleaseAllResources(const AppThreads& threads) {
+^
+DebugLog.cpp:125:0: style: The function 'Init' is never used. [unusedFunction]
+bool DebugLogAsync::Init(const wchar_t* logFileName, size_t queueCapacity, bool alsoOutputDebugString) noexcept {
+^
+DebugLog.cpp:152:0: style: The function 'Shutdown' is never used. [unusedFunction]
+void DebugLogAsync::Shutdown() noexcept {
+^
+DebugLog.cpp:168:0: style: The function 'ForceFlush' is never used. [unusedFunction]
+void DebugLogAsync::ForceFlush() noexcept {
+^
+DebugLog.cpp:174:0: style: The function 'SetEnabled' is never used. [unusedFunction]
+void DebugLogAsync::SetEnabled(bool enabled) noexcept {
+^
+Globals.h:40:0: style: The function 'BumpStreamGeneration' is never used. [unusedFunction]
+inline void BumpStreamGeneration() {
+^
+Globals.h:88:0: style: The function 'PointerToWString' is never used. [unusedFunction]
+std::wstring PointerToWString(T* ptr) {
+^
+Globals.h:98:0: style: The function 'HResultToHexWString' is never used. [unusedFunction]
+inline std::wstring HResultToHexWString(HRESULT hr) {
+^
+ReedSolomon.cpp:14:0: style: The function 'EncodeFEC_Jerasure' is never used. [unusedFunction]
+bool EncodeFEC_Jerasure(
+^
+ReedSolomon.cpp:53:0: style: The function 'DecodeFEC_Jerasure' is never used. [unusedFunction]
+bool DecodeFEC_Jerasure(
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:518:0: style: The function 'nomove' is never used. [unusedFunction]
+ static inline T const& nomove(T const& x)
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:693:0: style: The function 'valid' is never used. [unusedFunction]
+ inline bool valid() const { return producer != nullptr; }
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1060:0: style: The function 'try_enqueue' is never used. [unusedFunction]
+ inline bool try_enqueue(T const& item)
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1101:0: style: The function 'try_enqueue_bulk' is never used. [unusedFunction]
+ bool try_enqueue_bulk(It itemFirst, size_t count)
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1168:0: style: The function 'try_dequeue_non_interleaved' is never used. [unusedFunction]
+ bool try_dequeue_non_interleaved(U& item)
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1231:0: style: The function 'try_dequeue_bulk' is never used. [unusedFunction]
+ size_t try_dequeue_bulk(It itemFirst, size_t max)
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1300:0: style: The function 'try_dequeue_from_producer' is never used. [unusedFunction]
+ inline bool try_dequeue_from_producer(producer_token_t const& producer, U& item)
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1313:0: style: The function 'try_dequeue_bulk_from_producer' is never used. [unusedFunction]
+ inline size_t try_dequeue_bulk_from_producer(producer_token_t const& producer, It itemFirst, size_t max)
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1338:0: style: The function 'is_lock_free' is never used. [unusedFunction]
+ static constexpr bool is_lock_free()
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:1744:0: style: The function 'getTail' is never used. [unusedFunction]
+  inline index_t getTail() const { return tailIndex.load(std::memory_order_relaxed); }
+^
+concurrentqueue_x64-windows/include/concurrentqueue/concurrentqueue.h:3214:0: style: The function 'getMemStats' is never used. [unusedFunction]
+  MemStats getMemStats()
+^
+nvdec.cpp:772:0: style: The function 'NvdecThread' is never used. [unusedFunction]
+void NvdecThread(int threadId) {
+^
+nofile:0:0: information: Active checkers: There was critical errors (use --checkers-report=<filename> to see details) [checkersReport]


### PR DESCRIPTION
This commit fixes an intermittent rendering stall that occurs during window resizing.

The changes include:
- Forcing resolution announcements on all resize paths to ensure an IDR frame is requested, preventing synchronization issues.
- Adding a render kick on WM_SIZE messages to ensure the render loop executes promptly after a resize.
- Adding a guard against zero-size resizes in the swap-chain logic to prevent potential DXGI errors during minimize/restore operations.

These changes ensure that rendering remains smooth and does not stall during any type of window resize operation.