### PR TITLE
This commit introduces several optimizations to reduce the WGC to Ren…

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -125,6 +125,7 @@ struct ReadyGpuFrame {
     uint64_t present_ms = 0;       // Client steady clock: right after Present returns
     uint64_t fence_done_ms = 0;    // Client steady clock: after per-frame fence wait (if any)
     CUevent copyDone = nullptr; // NEW: signaled when NVDEC->CUDA copy has finished
+    UINT64 copyFenceValue = 0; // NEW: D3D12 fence value for D3D-CUDA sync
     nvtxRangeId_t nvtx_range_id = 0;
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -43,6 +43,7 @@ using namespace DebugLogAsync;
 #include <sstream>
 #include "concurrentqueue/concurrentqueue.h"
 #include <enet/enet.h>
+#include <wchar.h> // For wcsstr
 #include <nvtx3/nvtx3.hpp>
 #include "Globals.h"
 #include "nvdec.h"
@@ -1141,6 +1142,14 @@ ThreadConfig getOptimalThreadConfig(){
     config.render = 1;
     config.RS_K = 6;
     config.RS_M = 2;
+
+    // Check for latency profile override from command line
+    if (wcsstr(GetCommandLineW(), L"--fec_profile=latency")) {
+        config.RS_K = 5;
+        // Keep M/K ratio similar. Original is 2/6 ~= 0.33. New M for K=5 is 5*0.33~=1.66 -> 2.
+        config.RS_M = 2;
+        DebugLog(L"Low-latency FEC profile enabled via command line: K=5, M=2");
+    }
 
     return config;
 }

--- a/nvdec.h
+++ b/nvdec.h
@@ -30,7 +30,7 @@ struct FrameTimings {
 
 class FrameDecoder {
 public:
-    static const int NUM_DECODE_SURFACES = 20;
+    static const int NUM_DECODE_SURFACES = 3; // Reduced from 20 for lower latency
     
     FrameDecoder(CUcontext cuContext, ID3D12Device* pD3D12Device);
     ~FrameDecoder();

--- a/window.h
+++ b/window.h
@@ -1,8 +1,14 @@
 #include <windows.h>
 #include <wrl/client.h>
 #include <atomic>
+#include <cuda.h> // For CUexternalSemaphore
 
 extern std::atomic<bool> g_isSizing;
+
+// For D3D12/CUDA interop
+extern CUexternalSemaphore g_cudaCopyFenceSem;
+UINT64 NextCopyFenceValue() noexcept;
+
 
 bool InitWindow(HINSTANCE hInstance, int nCmdShow);
 bool InitD3D();


### PR DESCRIPTION
…derEnd latency to under 50ms. The changes focus on removing CPU waits, reducing pipeline depth, and making scheduling more aggressive.

The following changes are included:

- (A-1) Reorder Thresholds:
  - `REORDER_MAX_BUFFER` is reduced from 4 to 2.
  - The reorder wait policy in `GetReorderWaitMsForDepth` is made more aggressive, returning 1ms or 0ms to avoid micro-waits.

- (A-2) GPU-GPU Synchronization:
  - Replaced the CPU-blocking `cuEventSynchronize` on the render thread with a GPU-side synchronization mechanism.
  - A shared D3D12 fence is now signaled from the CUDA stream when a frame copy completes.
  - The D3D12 command queue on the render thread waits on this fence, removing CPU stalls and improving the copy/draw pipeline overlap.

- (A-3) Remove Pre-Wait:
  - Removed the explicit pre-wait on the DXGI frame latency waitable object (`g_frameLatencyWaitableObject`).
  - This relies solely on `Present()` for back-pressure, reducing CPU-side stalls.

- (B-1) Swap Chain Buffers:
  - Reduced `kSwapChainBufferCount` from 3 to 2 to decrease pipeline depth.

- (B-2) Low-Latency FEC Profile:
  - Introduced a low-latency profile, activated by the `--fec_profile=latency` command-line flag.
  - In this profile, the FEC block size `RS_K` is reduced from 6 to 5 to decrease upstream delay from late shards. `RS_M` is kept at 2 to maintain a similar redundancy ratio.

- (B-3) NVDEC Surface Counts:
  - Reduced the number of NVDEC decode and output surfaces to minimal values to avoid extra queuing.
  - `NUM_DECODE_SURFACES` was reduced from 20 to 3.
  - `ulNumOutputSurfaces` was reduced from 12 to 3.