### PR TITLE
This commit introduces several optimizations to reduce the WGC to Ren…

### DIFF
--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -1,3 +1,4 @@
+#include <cuda_d3d12_interop.h>
 #include "nvdec.h"
 #include "Globals.h"
 #include "window.h" // For NextCopyFenceValue and g_cudaCopyFenceSem

--- a/window.cpp
+++ b/window.cpp
@@ -14,7 +14,6 @@
 #include <iostream>
 #include <stdexcept>
 #include <cstring>
-#include "window.h"
 #include "DebugLog.h"
 #include "ReedSolomon.h"
 #include <algorithm> // For std::min, std::abs
@@ -39,6 +38,7 @@ void RequestIDRNow(); // defined in main.cpp; used to re-sync stream after devic
 // CUDA includes
 #include <cuda.h>
 #include <cuda_runtime_api.h>
+#include <cuda_d3d12_interop.h>
 
 // ==== [Multi-monitor helpers - BEGIN] ====
 #ifndef _USE_MATH_DEFINES


### PR DESCRIPTION
…derEnd latency to under 50ms. The changes focus on removing CPU waits, reducing pipeline depth, and making scheduling more aggressive.

The following changes are included:

- (A-1) Reorder Thresholds:
  - `REORDER_MAX_BUFFER` is reduced from 4 to 2.
  - The reorder wait policy in `GetReorderWaitMsForDepth` is made more aggressive, returning 1ms or 0ms to avoid micro-waits.

- (A-2) GPU-GPU Synchronization:
  - Replaced the CPU-blocking `cuEventSynchronize` on the render thread with a GPU-side synchronization mechanism.
  - A shared D3D12 fence is now signaled from the CUDA stream when a frame copy completes.
  - The D3D12 command queue on the render thread waits on this fence, removing CPU stalls and improving the copy/draw pipeline overlap.
  - Included `<cuda_d3d12_interop.h>` to resolve build errors related to undefined CUDA interop types.

- (A-3) Remove Pre-Wait:
  - Removed the explicit pre-wait on the DXGI frame latency waitable object (`g_frameLatencyWaitableObject`).
  - This relies solely on `Present()` for back-pressure, reducing CPU-side stalls.

- (B-1) Swap Chain Buffers:
  - Reduced `kSwapChainBufferCount` from 3 to 2 to decrease pipeline depth.

- (B-2) Low-Latency FEC Profile:
  - Introduced a low-latency profile, activated by the `--fec_profile=latency` command-line flag.
  - In this profile, the FEC block size `RS_K` is reduced from 6 to 5 to decrease upstream delay from late shards. `RS_M` is kept at 2 to maintain a similar redundancy ratio.

- (B-3) NVDEC Surface Counts:
  - Reduced the number of NVDEC decode and output surfaces to minimal values to avoid extra queuing.
  - `NUM_DECODE_SURFACES` was reduced from 20 to 3.
  - `ulNumOutputSurfaces` was reduced from 12 to 3.