### PR TITLE
Fix(corr): Unify external memory and semaphore calls to CUDA Driver API

### DIFF
--- a/nvdec.h
+++ b/nvdec.h
@@ -70,8 +70,8 @@ private:
         Microsoft::WRL::ComPtr<ID3D12Heap> pHeapUV;
         Microsoft::WRL::ComPtr<ID3D12Resource> pTextureY;
         Microsoft::WRL::ComPtr<ID3D12Resource> pTextureUV;
-        cudaExternalMemory_t cudaExtMemY;
-        cudaExternalMemory_t cudaExtMemUV;
+        CUexternalMemory cudaExtMemY;
+        CUexternalMemory cudaExtMemUV;
         CUmipmappedArray pMipmappedArrayY;
         CUmipmappedArray pMipmappedArrayUV;
         CUarray pCudaArrayY;


### PR DESCRIPTION
This commit corrects the previous attempt to fix compilation errors by fully migrating external memory and semaphore operations from the CUDA Runtime API to the Driver API.

The previous patch was incomplete, leading to new compilation errors. This patch addresses those by:
1.  Changing the type of external memory handles in the `DecodedFrameResource` struct (`nvdec.h`) from `cudaExternalMemory_t` to `CUexternalMemory`.
2.  Correcting the initialization of the `CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC` struct in `MapTextureMipArray` to use the valid Driver API members (`arrayDesc.Format`, `arrayDesc.NumChannels`, etc.).

With these changes, the code now consistently uses the Driver API for the specified operations, resolving all reported compilation errors.