### PR TITLE
Fix: Correct application shutdown order to prevent crash on exit

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1368,9 +1368,8 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
     // This single call handles joining all threads and releasing all resources idempotently.
     ReleaseAllResources(appThreads);
     
-    DebugLog(L"Cleanup complete. Exiting wWinMain.");
-
     // === 非同期ロガーを安全に停止（全ログを flush） ===
-    Shutdown();
+    // This MUST be the last action to ensure all other threads have finished and logged.
+    DebugLogAsync::Shutdown();
     return 0;
 }


### PR DESCRIPTION
Resolves a runtime crash in `std::thread::~thread()` that occurred during program exit.

The crash was caused by the asynchronous logger's worker thread (`g_worker` in `DebugLog.cpp`) not being joined before its global destructor was called.

The fix is to modify the shutdown sequence in `wWinMain` (`main.cpp`):
1.  All application threads are joined via `ReleaseAllResources()`.
2.  The asynchronous logger is shut down via `DebugLogAsync::Shutdown()` as the final step.

This ensures that no other threads can enqueue log messages after the logger shutdown has commenced, allowing the logger thread to exit its work loop and be joined successfully.