### PR TITLE
feat: Optimize FEC path and reduce copies

### DIFF
--- a/ReedSolomon.cpp
+++ b/ReedSolomon.cpp
@@ -10,6 +10,28 @@
 #include "ReedSolomon.h" // ※ ヘッダーファイルのインクルードを追加
 #include "Globals.h"
 
+// Static/file-local FECContext for reuse (no public header changes)
+namespace {
+    struct FECContext {
+        int k{-1}, m{-1};
+        size_t shard_len{0};
+        std::vector<char*> data_ptrs;
+        std::vector<char*> coding_ptrs;
+        std::vector<int>   erasures;      // size m+1
+        std::vector<uint8_t> parity_scratch; // m * shard_len
+        void ensure(int k_, int m_, size_t shard_len_) {
+            if (k != k_ || m != m_ || shard_len != shard_len_) {
+                k = k_; m = m_; shard_len = shard_len_;
+                data_ptrs.assign(k, nullptr);
+                coding_ptrs.assign(m, nullptr);
+                erasures.assign(m + 1, -1);
+                parity_scratch.resize(static_cast<size_t>(m) * shard_len);
+            }
+        }
+    };
+    static FECContext g_fecctx; // reuse across calls
+}
+
 // Jerasure を使った FEC エンコード関数
 bool EncodeFEC_Jerasure(
     const uint8_t* data,           // パディング済み入力データ
@@ -25,24 +47,27 @@ bool EncodeFEC_Jerasure(
         return false;
     }
 
-    // データシャードとパリティシャードのポインタ配列を作成 (char** 型)
-    std::vector<char*> data_ptrs(k);
-    std::vector<char*> coding_ptrs(m);
+    // Ensure reusable arrays are sized correctly.
+    g_fecctx.ensure(k, m, shard_len);
 
-    // パリティシャード用のメモリ確保とポインタ設定
-    parityShards.resize(m);
+    // Grow-only buffer strategy for parity shards to avoid re-allocation.
+    if (parityShards.size() != static_cast<size_t>(m)) {
+        parityShards.resize(m);
+    }
     for (int i = 0; i < m; ++i) {
-        parityShards[i].resize(shard_len);
-        coding_ptrs[i] = reinterpret_cast<char*>(parityShards[i].data());
+        if (parityShards[i].size() != shard_len) {
+            parityShards[i].resize(shard_len);
+        }
+        g_fecctx.coding_ptrs[i] = reinterpret_cast<char*>(parityShards[i].data());
     }
 
-    // データシャードポインタ設定 (入力データを直接参照)
+    // Data shard pointers point directly to the input data slices.
     for (int i = 0; i < k; ++i) {
-        data_ptrs[i] = const_cast<char*>(reinterpret_cast<const char*>(data)) + i * shard_len;
+        g_fecctx.data_ptrs[i] = const_cast<char*>(reinterpret_cast<const char*>(data)) + i * shard_len;
     }
 
     // Jerasure でエンコードを実行 (ビット行列を使用, w=8)
-    jerasure_bitmatrix_encode(k, m, 8, matrix, data_ptrs.data(), coding_ptrs.data(), shard_len, static_cast<int>(shard_len / 8));
+    jerasure_bitmatrix_encode(k, m, 8, matrix, g_fecctx.data_ptrs.data(), g_fecctx.coding_ptrs.data(), shard_len, static_cast<int>(shard_len / 8));
 
     // Jerasure 関数は通常エラーコードを返さないため、成功とみなす
     return true;
@@ -58,15 +83,14 @@ bool DecodeFEC_Jerasure(
     std::vector<uint8_t>& decodedData,  // 出力先
     const int* bitmatrix)             // ※ デコードに使用するビット行列
 {
-    if (receivedShards.size() < k) {
-        DebugLog(L"DecodeFEC_Jerasure Error: Not enough shards received (" + std::to_wstring(receivedShards.size()) + L" < " + std::to_wstring(k) + L")");
+    if (receivedShards.size() < static_cast<size_t>(k)) {
+        DebugLog(L"DecodeFEC_Jerasure Error: Not enough shards received (" +
+                 std::to_wstring(receivedShards.size()) + L" < " + std::to_wstring(k) + L")");
         return false;
     }
 
-    int n = k + m;
+    // Derive shard_len from first present shard
     size_t shard_len = 0;
-
-    // シャード長を取得
     if (!receivedShards.empty()) {
         shard_len = receivedShards.begin()->second.size();
     }
@@ -75,94 +99,91 @@ bool DecodeFEC_Jerasure(
         return false;
     }
 
-    // --- デコード処理 ---
-    std::vector<char*> data_ptrs(k);   // 元のデータシャードへのポインタ
-    std::vector<char*> coding_ptrs(m); // 元のパリティシャードへのポインタ
-    std::vector<int> erasures(m + 1);  // 消失したシャードのインデックスリスト (-1終了)
-    int num_erasures = 0;
-    std::vector<std::vector<uint8_t>> temp_shards(n); // 受信/復元シャードの一時格納用
-
-    // --- 受信シャードを一時バッファにコピーし、消失を記録 ---
-    for (int i = 0; i < n; ++i) {
-        auto it = receivedShards.find(i);
-        bool is_shard_valid = (it != receivedShards.end() && it->second.size() == shard_len);
-
-        if (is_shard_valid) {
-            // Valid shard received
-            temp_shards[i] = it->second;
-        } else {
-            // Shard is missing or invalid, treat as an erasure.
-            if (num_erasures < m) {
-                erasures[num_erasures++] = i;
-                temp_shards[i].resize(shard_len, 0); // Allocate a buffer for the recovery
-            } else {
-                // Too many erasures to recover.
-                DebugLog(L"DecodeFEC_Jerasure Error: Too many erasures (" + std::to_wstring(num_erasures + 1) + L" > " + std::to_wstring(m) + L")");
-                return false;
-            }
-        }
-
-        // Set up the pointers for Jerasure
-        if (i < k) {
-            data_ptrs[i] = reinterpret_cast<char*>(temp_shards[i].data());
-        } else {
-            coding_ptrs[i - k] = reinterpret_cast<char*>(temp_shards[i].data());
-        }
-    }
-    erasures[num_erasures] = -1; // 消失リストの終了マーカー
-
-    // --- デコード実行 ---
-    if (bitmatrix == nullptr) { // ※ 引数で渡されたビット行列をチェック
+    if (!bitmatrix) {
         DebugLog(L"DecodeFEC_Jerasure Error: Jerasure bitmatrix not provided for decoding.");
         return false;
     }
 
+    // Ensure reusable arrays
+    g_fecctx.ensure(k, m, shard_len);
 
-    // ※ jerasure_bitmatrix_decode を使用 ※
-    // row_k_ones はビット行列デコードでは通常不要 (またはの意味が異なる)
-    // packetsize は shard_len / w
-    int ret = jerasure_bitmatrix_decode(k, m, 8, const_cast<int*>(bitmatrix), 0, erasures.data(), data_ptrs.data(), coding_ptrs.data(), shard_len, static_cast<int>(shard_len / 8));
+    // 1) Pre-size output once (k * shard_len)
+    decodedData.clear();
+    decodedData.resize(static_cast<size_t>(k) * shard_len);
+
+    // 2) Data shard pointers point directly into decodedData.
+    for (int i = 0; i < k; ++i) {
+        g_fecctx.data_ptrs[i] = reinterpret_cast<char*>(decodedData.data() + static_cast<size_t>(i) * shard_len);
+    }
+
+    // 3) Coding shard pointers point into one reusable parity_scratch block.
+    for (int j = 0; j < m; ++j) {
+        g_fecctx.coding_ptrs[j] = reinterpret_cast<char*>(g_fecctx.parity_scratch.data() + static_cast<size_t>(j) * shard_len);
+    }
+
+    // 4) Fill received data shards directly into decodedData; record erasures for missing shards.
+    int erasure_count = 0;
+    const int n = k + m;
+    // Iterate through all possible shard indices to identify missing ones.
+    for (int i = 0; i < n; ++i) {
+        auto it = receivedShards.find(i);
+        const bool shard_is_present = (it != receivedShards.end() && it->second.size() == shard_len);
+
+        if (i < k) { // This is a data shard
+            if (shard_is_present) {
+                // Copy received shard data into its final destination in the output buffer. This is the ONLY copy.
+                std::memcpy(decodedData.data() + static_cast<size_t>(i) * shard_len, it->second.data(), shard_len);
+            } else {
+                // This data shard is missing. Record it as an erasure.
+                if (erasure_count < m) {
+                    g_fecctx.erasures[erasure_count++] = i;
+                    // No need to zero-fill the buffer; Jerasure will write the recovered data here.
+                } else {
+                    // This should not happen if receivedShards.size() >= k, but as a safeguard:
+                    DebugLog(L"DecodeFEC_Jerasure Error: Too many erasures detected (" +
+                             std::to_wstring(erasure_count + 1) + L" > " + std::to_wstring(m) + L")");
+                    return false;
+                }
+            }
+        } else { // This is a coding (parity) shard
+            if (shard_is_present) {
+                // We have a parity shard. Copy it into the reusable parity scratch buffer.
+                std::memcpy(g_fecctx.parity_scratch.data() + static_cast<size_t>(i - k) * shard_len, it->second.data(), shard_len);
+            } else {
+                // This coding shard is missing. Record it as an erasure.
+                if (erasure_count < m) {
+                    g_fecctx.erasures[erasure_count++] = i;
+                } else {
+                    DebugLog(L"DecodeFEC_Jerasure Error: Too many erasures detected (" +
+                             std::to_wstring(erasure_count + 1) + L" > " + std::to_wstring(m) + L")");
+                    return false;
+                }
+            }
+        }
+    }
+    g_fecctx.erasures[erasure_count] = -1; // Null-terminate the erasures list for Jerasure.
+
+    // 5) Decode — recovered bytes go straight into decodedData via data_ptrs.
+    const int ret = jerasure_bitmatrix_decode(
+        k, m, 8, const_cast<int*>(bitmatrix),
+        /*row_k_ones*/ 0,
+        g_fecctx.erasures.data(),
+        g_fecctx.data_ptrs.data(),
+        g_fecctx.coding_ptrs.data(),
+        static_cast<int>(shard_len),
+        static_cast<int>(shard_len / 8)
+    );
     if (ret == -1) {
         DebugLog(L"DecodeFEC_Jerasure Error: jerasure_matrix_decode failed (matrix not invertible?).");
-        return false; // デコード失敗
+        return false;
     }
 
-    // --- 元データの再構築 ---
-    decodedData.clear();
-    decodedData.reserve(k * shard_len); // 最大のサイズを予約 (パディング込み)
-
-    /*DebugLog(L"DecodeFEC_Jerasure: Reconstructing data. k=" + std::to_wstring(k) +
-             L", m=" + std::to_wstring(m) +
-             L", shard_len=" + std::to_wstring(shard_len) +
-             L", originalDataLen=" + std::to_wstring(originalDataLen));*/
-
-
-    for (int i = 0; i < k; ++i) {
-        if (temp_shards[i].size() < shard_len) {
-            DebugLog(L"DecodeFEC_Jerasure Warning: temp_shards[" + std::to_wstring(i) +
-                     L"].size() (" + std::to_wstring(temp_shards[i].size()) +
-                     L") is less than shard_len (" + std::to_wstring(shard_len) + L")");
-            // ここで処理を中断するか、エラーとするかは仕様次第
-        }
-        // temp_shards[i] には、受信したか復元されたデータシャードが格納されている
-        // shard_len バイト分を decodedData に追加する
-        decodedData.insert(decodedData.end(), temp_shards[i].begin(), temp_shards[i].begin() + shard_len);
-    }
-
-    //DebugLog(L"DecodeFEC_Jerasure: Before resize, decodedData.size()=" + std::to_wstring(decodedData.size()));
-
-    // パディングを除去
-    // decodedData の現在のサイズが originalDataLen より大きい場合、originalDataLen にリサイズする
+    // 6) Trim to original length (preserve timing/logs around this function)
     if (decodedData.size() > originalDataLen) {
         decodedData.resize(originalDataLen);
     } else if (decodedData.size() < originalDataLen) {
-        // このケースは通常発生しないはずだが、念のため警告を出す
-        DebugLog(L"DecodeFEC_Jerasure Warning: Reconstructed data is shorter than originalDataLen. Size: " +
-            std::to_wstring(decodedData.size()) + L", Original: " + std::to_wstring(originalDataLen));
+        DebugLog(L"DecodeFEC_Jerasure Warning: Reconstructed data shorter than originalDataLen. Size: " +
+                 std::to_wstring(decodedData.size()) + L", Original: " + std::to_wstring(originalDataLen));
     }
-    // decodedData.size() == originalDataLen の場合は何もしない
-
-    //DebugLog(L"DecodeFEC_Jerasure: After resize, decodedData.size()=" + std::to_wstring(decodedData.size()));
-
     return true;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -463,7 +463,7 @@ public:
         if (m_pq.empty()) {
             return false;
         }
-        item_out = m_pq.top(); // This is a copy operation from const T&
+        item_out = std::move(const_cast<T&>(m_pq.top()));
         m_pq.pop();
         return true;
     }


### PR DESCRIPTION
This commit introduces several performance improvements to the FEC and data handling paths.

1.  **Eliminate Double Copy in FEC Decode:** The `DecodeFEC_Jerasure` function has been rewritten to decode directly into the final output buffer. It no longer uses an intermediate `std::vector<std::vector<uint8_t>>` for shards, which previously required a second pass to assemble the final data. This significantly reduces CPU usage and memory traffic during frame reconstruction.

2.  **Reusable Buffers for FEC:** A context object (`FECContext`) has been introduced to manage and reuse memory buffers (`data_ptrs`, `coding_ptrs`, `erasures`, scratch space) across calls to encode and decode functions. Buffers are now only reallocated when FEC parameters (k, m, shard_len) change, avoiding per-call allocation churn. The `EncodeFEC_Jerasure` function was also updated to use a grow-only strategy for parity shard buffers.

3.  **Optimize Priority Queue Dequeue:** The `ThreadSafePriorityQueue::try_dequeue` method has been changed to use `std::move` instead of a copy assignment. This prevents the `ParsedShardInfo` struct, which contains a `std::vector`, from being copied on every dequeue operation, reducing overhead in the FecWorkerThread.