### PR TITLE
fix(build): Remove erroneous call to std::map::reserve

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1085,7 +1085,6 @@ void FecWorkerThread(int threadId) {
 
                             // [重要] shardsForDecodeAttempt には「多数派長のシャードのみ」を詰める
                             shardsForDecodeAttempt.clear();
-                            shardsForDecodeAttempt.reserve(mode_cnt);
                             for (auto &pair_entry : frameBuf) {
                                 if (pair_entry.second.size() == mode_len) {
                                     // デコーダは map<uint32_t, vector<uint8_t>> を受け取るためコピーになる


### PR DESCRIPTION
This commit fixes a compilation error caused by attempting to call `.reserve()` on a `std::map` object. `std::map` does not support this member function.

The line has been removed to allow the code to compile correctly. The performance impact is negligible.