### PR TITLE
feat(perf): Optimize packet processing performance

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -735,7 +735,7 @@ void ReceiveRawPacketsThread(int threadId) { // Renaming to ReceiveENetPacketsTh
     for (auto& s : rb) s.buf.reserve(kRingSlotCap);
     size_t rbHead = 0;
 
-    auto& nextSlot = [&]()->std::vector<uint8_t>& {
+    auto nextSlot = [&]()->std::vector<uint8_t>& {
         auto& v = rb[rbHead].buf;
         rbHead = (rbHead + 1) % kRingSlots;
         return v;


### PR DESCRIPTION
Replaced `std::map` with `std::unordered_map` for various data structures in the hot path, such as `g_frameBuffer`, `appFragmentBuffers`, and `g_frameMetadata`, to improve lookup times from O(logN) to average O(1).

Introduced a ring buffer of pre-allocated vectors in `ReceiveRawPacketsThread` to serve as a workspace for reassembling packet fragments. This avoids frequent heap allocations and reduces memory fragmentation.

Replaced `std::vector::assign` with `resize` and `memcpy` for copying shard data to prevent potential reallocations and improve performance stability.

Preserved all existing logging, comments, and NVTX ranges as requested.

fix(build): Correct lambda declaration to fix C2440

Changed `auto& nextSlot` to `auto nextSlot` to prevent binding an rvalue (the lambda object) to a non-const lvalue reference.