### PR TITLE
feat: Add support for HEVC YUV 4:4:4 decoding and rendering

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -108,7 +108,8 @@ inline std::wstring HResultToHexWString(HRESULT hr) {
 struct ReadyGpuFrame {
     uint64_t timestamp;    
     Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_Y;  // Y plane texture
-    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_UV; // UV plane texture
+    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_U; // U plane texture
+    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_V; // V plane texture
     int width;
     int height;
     uint32_t originalFrameNumber;

--- a/Shader/YUV444ToRGBA709Full.hlsl
+++ b/Shader/YUV444ToRGBA709Full.hlsl
@@ -1,0 +1,55 @@
+// YUV444ToRGBA709Full.hlsl
+// 目的: HEVC 4:4:4 (BT.709, Full Range) 入力の YUV444 → RGBA 変換
+// 注意: 余分な処理は行わない / goto は使わない / 既存のログ・計測は C++ 側で維持
+
+Texture2D TextureY : register(t0); // R8_UNORM or R16_UNORM (0..1 に正規化)
+Texture2D TextureU : register(t1); // R8_UNORM or R16_UNORM
+Texture2D TextureV : register(t2); // R8_UNORM or R16_UNORM
+SamplerState Sampler : register(s0); // point/clamp を推奨（D3D12 側の静的サンプラ設定）
+
+// 切替マクロ
+#ifndef FULL_RANGE
+  #define FULL_RANGE 1 // このシェーダは Full Range 前提
+#endif
+#ifndef USE_BT601
+  #define USE_BT601 0 // 0: BT.709, 1: BT.601
+#endif
+
+// BT.709 Full Range 係数（Y はそのまま, U/V は ±0.5 中心）
+float3 YUV709FullToRGB(float y, float u, float v)
+{
+    // Uc, Vc は中心 0 の偏差（-0.5..+0.5）
+    float uc = u - 0.5f;
+    float vc = v - 0.5f;
+
+#if USE_BT601
+    // 参考: BT.601 Full Range（必要なら切替）
+    float r = y + 1.4020f * vc;
+    float g = y - 0.3441f * uc - 0.7141f * vc;
+    float b = y + 1.7720f * uc;
+#else
+    // BT.709 Full Range
+    float r = y + 1.5748f * vc;
+    float g = y - 0.1873f * uc - 0.4681f * vc;
+    float b = y + 1.8556f * uc;
+#endif
+
+    return saturate(float3(r, g, b));
+}
+
+float4 main(float4 pos : SV_POSITION, float2 uv : TEXCOORD0) : SV_TARGET
+{
+    // Y, U, V はいずれもフル解像度（アップサンプル不要）
+    float y = TextureY.Sample(Sampler, uv).r;
+    float u = TextureU.Sample(Sampler, uv).r;
+    float v = TextureV.Sample(Sampler, uv).r;
+
+#if FULL_RANGE
+    // そのまま（Y:0..1, U/V:0..1）
+#else
+    // Limited→Full 変換を行う場合はここに追加（今回は Full 前提）
+#endif
+
+    float3 rgb = YUV709FullToRGB(y, u, v);
+    return float4(rgb, 1.0f);
+}

--- a/nvdec.h
+++ b/nvdec.h
@@ -67,19 +67,31 @@ private:
 
     struct DecodedFrameResource {
         Microsoft::WRL::ComPtr<ID3D12Heap> pHeapY;
-        Microsoft::WRL::ComPtr<ID3D12Heap> pHeapUV;
+        Microsoft::WRL::ComPtr<ID3D12Heap> pHeapUV; // Unused for 444
         Microsoft::WRL::ComPtr<ID3D12Resource> pTextureY;
-        Microsoft::WRL::ComPtr<ID3D12Resource> pTextureUV;
+        Microsoft::WRL::ComPtr<ID3D12Resource> pTextureUV; // Unused for 444
+        Microsoft::WRL::ComPtr<ID3D12Resource> pTextureU;
+        Microsoft::WRL::ComPtr<ID3D12Resource> pTextureV;
         CUexternalMemory cudaExtMemY;
-        CUexternalMemory cudaExtMemUV;
+        CUexternalMemory cudaExtMemUV; // Unused for 444
+        CUexternalMemory cudaExtMemU;
+        CUexternalMemory cudaExtMemV;
         CUmipmappedArray pMipmappedArrayY;
-        CUmipmappedArray pMipmappedArrayUV;
+        CUmipmappedArray pMipmappedArrayUV; // Unused for 444
+        CUmipmappedArray pMipmappedArrayU;
+        CUmipmappedArray pMipmappedArrayV;
         CUarray pCudaArrayY;
-        CUarray pCudaArrayUV;
+        CUarray pCudaArrayUV; // Unused for 444
+        CUarray pCudaArrayU;
+        CUarray pCudaArrayV;
         HANDLE sharedHandleY;
-        HANDLE sharedHandleUV;
+        HANDLE sharedHandleUV; // Unused for 444
+        HANDLE sharedHandleU;
+        HANDLE sharedHandleV;
         UINT pitchY;
-        UINT pitchUV;
+        UINT pitchUV; // Unused for 444
+        UINT pitchU;
+        UINT pitchV;
 
         // NEW: for async copy
         CUstream copyStream = nullptr;


### PR DESCRIPTION
This commit modifies the video processing pipeline to handle HEVC (H.265) 4:4:4 full-range video streams, in addition to the existing AV1 NV12 support.

Key changes include:
- **NVDEC Configuration:** Updated `nvdec.cpp` to configure the CUDA video parser for the HEVC codec and the decoder for the YUV 4:4:4 chroma format.
- **Resource Management:** Modified `nvdec.h` and `nvdec.cpp` to allocate three separate full-resolution D3D12 textures (Y, U, V) for 4:4:4 frames, with support for both 8-bit and high-bit-depth (16-bit) formats. The resource cleanup and retirement logic in `window.cpp` has been updated accordingly.
- **D3D12 Rendering Pipeline:** Updated `window.cpp` to support the 3-plane texture format. The root signature is expanded to handle three SRVs, and the SRV descriptor heap management is now dynamic, advancing by 3 for 4:4:4 frames and by 2 for NV12 frames.
- **New Pixel Shader:** Added a new pixel shader, `Shader/YUV444ToRGBA709Full.hlsl`, to perform the color space conversion from BT.709 YUV 4:4:4 full range to RGBA. The PSO now compiles and uses this shader when appropriate.
- **Maintained Compatibility:** The existing NV12 processing path is preserved to ensure no regressions for other video formats.