### PR TITLE
fix: Correctly handle both YUV444 and NV12 rendering paths

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -108,8 +108,9 @@ inline std::wstring HResultToHexWString(HRESULT hr) {
 struct ReadyGpuFrame {
     uint64_t timestamp;    
     Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_Y;  // Y plane texture
-    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_U; // U plane texture
-    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_V; // V plane texture
+    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_U; // U plane texture (for YUV444)
+    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_V; // V plane texture (for YUV444)
+    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_UV; // Interleaved UV plane texture (for NV12)
     int width;
     int height;
     uint32_t originalFrameNumber;

--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -780,7 +780,10 @@ int FrameDecoder::HandlePictureDisplay(void* pUserData, CUVIDPARSERDISPINFO* pDi
     if (is444) {
         readyFrame.hw_decoded_texture_U = fr.pTextureU;
         readyFrame.hw_decoded_texture_V = fr.pTextureV;
+        readyFrame.hw_decoded_texture_UV = nullptr; // Explicitly null for 444
     } else {
+        readyFrame.hw_decoded_texture_U = nullptr;
+        readyFrame.hw_decoded_texture_V = nullptr;
         readyFrame.hw_decoded_texture_UV = fr.pTextureUV;
     }
     readyFrame.timestamp             = pDispInfo->timestamp;

--- a/window.cpp
+++ b/window.cpp
@@ -626,6 +626,7 @@ void ClearReorderState()
             r.y = std::move(rf.hw_decoded_texture_Y);
             r.u = std::move(rf.hw_decoded_texture_U);
             r.v = std::move(rf.hw_decoded_texture_V);
+            r.uv = std::move(rf.hw_decoded_texture_UV);
             r.copyDone = rf.copyDone;      // hand the event to retire bin
             r.fenceValue = retireFence;    // conservative: release after this fence
 
@@ -646,12 +647,13 @@ void ClearReorderState()
         r.y = std::move(g_lastDrawnFrame.hw_decoded_texture_Y);
         r.u = std::move(g_lastDrawnFrame.hw_decoded_texture_U);
         r.v = std::move(g_lastDrawnFrame.hw_decoded_texture_V);
+        r.uv = std::move(g_lastDrawnFrame.hw_decoded_texture_UV);
         r.copyDone = g_lastDrawnFrame.copyDone;
         r.fenceValue = retireFence;
         g_lastDrawnFrame.copyDone = nullptr;
         g_lastDrawnFrame = {}; // keep existing layout/behavior
 
-        if (r.y || r.u || r.v || r.copyDone) {
+        if (r.y || r.u || r.v || r.uv || r.copyDone) {
             std::lock_guard<std::mutex> gb(g_retireBinMutex);
             g_retireBin.emplace_back(std::move(r));
         }


### PR DESCRIPTION
This commit fixes a compilation error introduced in the previous change for HEVC 4:4:4 support. The error was caused by completely removing the `hw_decoded_texture_UV` member from the `ReadyGpuFrame` struct, which broke the existing rendering path for NV12 video streams.

The fix involves:
- Re-introducing `hw_decoded_texture_UV` to the `ReadyGpuFrame` struct to maintain compatibility.
- Updating the resource cleanup logic in `ClearReorderState` to correctly handle all texture resources (`Y`, `U`, `V`, and `UV`).
- Adjusting the frame population logic in `nvdec.cpp` to correctly populate either the U/V textures (for 4:4:4) or the UV texture (for NV12), while nulling out the unused pointers.
- The rendering logic in `window.cpp` was already designed to be dynamic and works correctly with this change.