### PR TITLE
refactor: Remove NV12 format handling from NVDEC path

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -110,7 +110,6 @@ struct ReadyGpuFrame {
     Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_Y;  // Y plane texture
     Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_U; // U plane texture (for YUV444)
     Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_V; // V plane texture (for YUV444)
-    Microsoft::WRL::ComPtr<ID3D12Resource> hw_decoded_texture_UV; // Interleaved UV plane texture (for NV12)
     int width;
     int height;
     uint32_t originalFrameNumber;

--- a/nvdec.h
+++ b/nvdec.h
@@ -67,29 +67,22 @@ private:
 
     struct DecodedFrameResource {
         Microsoft::WRL::ComPtr<ID3D12Heap> pHeapY;
-        Microsoft::WRL::ComPtr<ID3D12Heap> pHeapUV; // Unused for 444
         Microsoft::WRL::ComPtr<ID3D12Resource> pTextureY;
-        Microsoft::WRL::ComPtr<ID3D12Resource> pTextureUV; // Unused for 444
         Microsoft::WRL::ComPtr<ID3D12Resource> pTextureU;
         Microsoft::WRL::ComPtr<ID3D12Resource> pTextureV;
         CUexternalMemory cudaExtMemY;
-        CUexternalMemory cudaExtMemUV; // Unused for 444
         CUexternalMemory cudaExtMemU;
         CUexternalMemory cudaExtMemV;
         CUmipmappedArray pMipmappedArrayY;
-        CUmipmappedArray pMipmappedArrayUV; // Unused for 444
         CUmipmappedArray pMipmappedArrayU;
         CUmipmappedArray pMipmappedArrayV;
         CUarray pCudaArrayY;
-        CUarray pCudaArrayUV; // Unused for 444
         CUarray pCudaArrayU;
         CUarray pCudaArrayV;
         HANDLE sharedHandleY;
-        HANDLE sharedHandleUV; // Unused for 444
         HANDLE sharedHandleU;
         HANDLE sharedHandleV;
         UINT pitchY;
-        UINT pitchUV; // Unused for 444
         UINT pitchU;
         UINT pitchV;
 


### PR DESCRIPTION
Removes all code paths, data structures, and logic related to the NV12 (YUV420) video format from the NVDEC decoder and D3D12 renderer.

The application is specified to only handle HEVC YUV444 streams, making the NV12 code redundant. This change simplifies the codebase by removing dead code and unnecessary branching, improving maintainability.

The following changes were made:
- Modified `nvdec.h` and `Globals.h` to remove NV12-specific fields from `DecodedFrameResource` and `ReadyGpuFrame` structs.
- Modified `nvdec.cpp` to eliminate NV12 logic in resource management, decoder creation, buffer allocation, and frame handling functions.
- Modified `window.cpp` to remove NV12 logic from the rendering path, including resource retirement and shader resource view creation. The rendering logic now exclusively handles 3-plane YUV444 textures.