### PR TITLE
Refactor H.264-specific names to be more generic

### DIFF
--- a/Globals.cpp
+++ b/Globals.cpp
@@ -40,10 +40,10 @@ std::atomic<bool> app_running_atomic(true);
 std::atomic<bool> g_isSizing{false};
 std::atomic<bool> g_showRebootOverlay{ false };
 std::atomic<bool> g_forcePresentOnce{false};
-std::atomic<bool> dumpHEVCToFiles(false);
+std::atomic<bool> dumpEncodedStreamToFiles{false};
 
-// H264 Frame queue
-moodycamel::ConcurrentQueue<H264Frame> g_h264FrameQueue;
+// Encoded Frame queue
+moodycamel::ConcurrentQueue<EncodedFrame> g_encodedFrameQueue;
 
 // FEC end times keyed by stream frame number (steady clock ms since epoch-like)
 std::unordered_map<uint32_t, uint64_t> g_fecEndTimeByStreamFrame;

--- a/Globals.h
+++ b/Globals.h
@@ -131,8 +131,8 @@ struct ReadyGpuFrame {
     nvtxRangeId_t nvtx_range_id = 0;
 };
 
-// H264 Frame Data for decoder queue
-struct H264Frame {
+// Encoded Frame Data for decoder queue
+struct EncodedFrame {
     uint64_t timestamp;
     uint32_t frameNumber;
     std::vector<uint8_t> data;
@@ -147,10 +147,10 @@ extern std::atomic<bool> app_running_atomic;
 extern std::atomic<bool> g_isSizing;
 extern std::atomic<bool> g_showRebootOverlay;
 extern std::atomic<bool> g_forcePresentOnce; // Present at least once even if no new decoded frame
-extern std::atomic<bool> dumpHEVCToFiles;
+extern std::atomic<bool> dumpEncodedStreamToFiles;
 
 // Global queues and synchronization for frame management
-extern moodycamel::ConcurrentQueue<H264Frame> g_h264FrameQueue;
+extern moodycamel::ConcurrentQueue<EncodedFrame> g_encodedFrameQueue;
 extern std::deque<ReadyGpuFrame> g_readyGpuFrameQueue;
 extern std::mutex g_readyGpuFrameQueueMutex;
 extern std::condition_variable g_readyGpuFrameQueueCV;

--- a/nvdec.cpp
+++ b/nvdec.cpp
@@ -237,7 +237,7 @@ bool FrameDecoder::Init() {
     return true;
 }
 
-void FrameDecoder::Decode(const H264Frame& frame) {
+void FrameDecoder::Decode(const EncodedFrame& frame) {
     CUDA_CHECK(cuCtxPushCurrent(m_cuContext));
 
     // timestamp -> frameNumber を記録 (from original)
@@ -796,12 +796,12 @@ void NvdecThread(int threadId) {
     }
 
     while (g_decode_worker_Running) { // Use the same global running flag
-        H264Frame frame;
-        if (g_h264FrameQueue.try_dequeue(frame)) {
+        EncodedFrame frame;
+        if (g_encodedFrameQueue.try_dequeue(frame)) {
             nvtx3::scoped_range r("CUDA Decode");
             frame.decode_start_ms = SteadyNowMs();
             g_frameDecoder->Decode(frame);
-            if(DecoderCount++ % 200 == 0)DebugLog(L"NvdecThread: Dequeue Size " + std::to_wstring(g_h264FrameQueue.size_approx()));
+            if(DecoderCount++ % 200 == 0)DebugLog(L"NvdecThread: Dequeue Size " + std::to_wstring(g_encodedFrameQueue.size_approx()));
         } else {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }


### PR DESCRIPTION
This commit refactors several identifiers in the codebase that were specific to the H.264 codec. As the application now handles HEVC streams, these names were misleading.

The following changes were made to improve code readability and maintainability:
- The `H264Frame` struct has been renamed to `EncodedFrame`.
- The global queue `g_h264FrameQueue` has been renamed to `g_encodedFrameQueue`.
- The file-saving function `SaveHEVCToFile_NUM` has been renamed to `SaveEncodedStreamToFile`.
- The debug flag `dumpHEVCToFiles` has been renamed to `dumpEncodedStreamToFiles`.

These changes have been applied consistently across `Globals.h`, `Globals.cpp`, `main.cpp`, and `nvdec.cpp`. No logical changes were made.