### PR TITLE
Remove NV12 stream handling and require HEVC YUV444

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -98,8 +98,7 @@ inline std::wstring HResultToHexWString(HRESULT hr) {
 }
 
 enum class PlaneLayout : uint32_t {
-    YUV444,
-    NV12
+    YUV444
 };
 
 // ReadyGpuFrame struct for D3D12

--- a/window.cpp
+++ b/window.cpp
@@ -614,7 +614,6 @@ static std::chrono::steady_clock::time_point g_lastReorderDecision = std::chrono
 // Rendering specific D3D12 globals
 Microsoft::WRL::ComPtr<ID3D12RootSignature> g_rootSignature;
 Microsoft::WRL::ComPtr<ID3D12PipelineState> g_pipelineStateYuv444;
-Microsoft::WRL::ComPtr<ID3D12PipelineState> g_pipelineStateNv12;
 Microsoft::WRL::ComPtr<ID3D12Resource> g_vertexBuffer;
 D3D12_VERTEX_BUFFER_VIEW g_vertexBufferView;
 Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> g_srvHeap; // For Y and UV textures
@@ -913,7 +912,6 @@ bool InitD3D() {
     if (g_srvHeap) g_srvHeap.Reset();
     if (g_vertexBuffer) g_vertexBuffer.Reset();
     if (g_pipelineStateYuv444) g_pipelineStateYuv444.Reset();
-    if (g_pipelineStateNv12) g_pipelineStateNv12.Reset();
     if (g_rootSignature) g_rootSignature.Reset();
     if (g_d3d12Device) g_d3d12Device.Reset();
     if (g_fenceEvent) { CloseHandle(g_fenceEvent); g_fenceEvent = nullptr; }
@@ -1178,7 +1176,6 @@ if (FAILED(hr) || !g_copyFenceSharedHandle) {
     // 10. Create PSO
     Microsoft::WRL::ComPtr<ID3DBlob> vertexShaderBlob;
     Microsoft::WRL::ComPtr<ID3DBlob> pixelShaderBlobYuv444;
-    Microsoft::WRL::ComPtr<ID3DBlob> pixelShaderBlobNv12;
 
     UINT compileFlags = D3DCOMPILE_ENABLE_STRICTNESS;
 #if defined(_DEBUG)
@@ -1195,13 +1192,6 @@ if (FAILED(hr) || !g_copyFenceSharedHandle) {
     if (FAILED(hr)) {
         if (errorBlob) DebugLog(L"InitD3D (D3D12): Pixel shader compilation failed: " + std::wstring(static_cast<wchar_t*>(errorBlob->GetBufferPointer()), static_cast<wchar_t*>(errorBlob->GetBufferPointer()) + errorBlob->GetBufferSize() / sizeof(wchar_t)));
         else DebugLog(L"InitD3D (D3D12): Pixel shader compilation failed. HR: " + HResultToHexWString(hr));
-        return false;
-    }
-
-    hr = D3DCompileFromFile(L"Shader/NV12ToRGBA709Full.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_1", compileFlags, 0, &pixelShaderBlobNv12, &errorBlob);
-    if (FAILED(hr)) {
-        if (errorBlob) DebugLog(L"InitD3D (D3D12): NV12 pixel shader compilation failed: " + std::wstring(static_cast<wchar_t*>(errorBlob->GetBufferPointer()), static_cast<wchar_t*>(errorBlob->GetBufferPointer()) + errorBlob->GetBufferSize() / sizeof(wchar_t)));
-        else DebugLog(L"InitD3D (D3D12): NV12 pixel shader compilation failed. HR: " + HResultToHexWString(hr));
         return false;
     }
 
@@ -1227,15 +1217,6 @@ if (FAILED(hr) || !g_copyFenceSharedHandle) {
         return false;
     }
     DebugLog(L"InitD3D (D3D12): PSO created.");
-
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC nv12Desc = psoDesc;
-    nv12Desc.PS = CD3DX12_SHADER_BYTECODE(pixelShaderBlobNv12.Get());
-    hr = g_d3d12Device->CreateGraphicsPipelineState(&nv12Desc, IID_PPV_ARGS(&g_pipelineStateNv12));
-    if (FAILED(hr)) {
-        DebugLog(L"InitD3D (D3D12): Failed to create NV12 PSO. HR: " + HResultToHexWString(hr));
-        return false;
-    }
-    DebugLog(L"InitD3D (D3D12): NV12 PSO created.");
 
     // 11. Create SRV Descriptor Heap (for Y and UV textures)
     D3D12_DESCRIPTOR_HEAP_DESC srvHeapDesc = {};
@@ -1721,10 +1702,8 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
     }
 
     // 3. Draw the selected frame.
-    const bool isNv12Layout = (frameToDraw.planeLayout == PlaneLayout::NV12);
-    const bool isYuv444Layout = (frameToDraw.planeLayout == PlaneLayout::YUV444);
     const bool canDrawFrame = frameToDraw.hw_decoded_texture_Y && frameToDraw.hw_decoded_texture_U &&
-        ((isYuv444Layout && frameToDraw.hw_decoded_texture_V) || isNv12Layout);
+        frameToDraw.hw_decoded_texture_V;
     if (canDrawFrame) {
         if (isNewFrame) {
             frameToDraw.render_start_ms = SteadyNowMs();
@@ -1742,7 +1721,7 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
             }
         }
 
-        g_commandList->SetPipelineState(isNv12Layout ? g_pipelineStateNv12.Get() : g_pipelineStateYuv444.Get());
+        g_commandList->SetPipelineState(g_pipelineStateYuv444.Get());
 
         // Use display dimensions for letterboxing, not coded dimensions or window dimensions.
         const int videoW = frameToDraw.displayW;
@@ -1766,7 +1745,7 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
 
         // --- SRV setup (Y, U[, V]) ---
         // 連続スロットを保証するための wrap 前処理（性能影響なし）
-        const UINT kNeededSrv = isNv12Layout ? 2u : 3u;
+        const UINT kNeededSrv = 3u;
         if (g_srvDescriptorHeapIndex + kNeededSrv > kSrvHeapSize) {
             // ★ wrap：ヒープ末尾近くで3連続確保できない場合は先頭に巻き戻す
             g_srvDescriptorHeapIndex = 0;
@@ -1795,14 +1774,12 @@ bool PopulateCommandList(ReadyGpuFrame& outFrameToRender) { // Return bool, pass
         srvDesc.Format = frameToDraw.hw_decoded_texture_U->GetDesc().Format;
         g_d3d12Device->CreateShaderResourceView(
             frameToDraw.hw_decoded_texture_U.Get(), &srvDesc, srvHandleCpu);
-        if (!isNv12Layout) {
-            srvHandleCpu.Offset(1, g_srvDescriptorSize);
+        srvHandleCpu.Offset(1, g_srvDescriptorSize);
 
-            // V plane
-            srvDesc.Format = frameToDraw.hw_decoded_texture_V->GetDesc().Format;
-            g_d3d12Device->CreateShaderResourceView(
-                frameToDraw.hw_decoded_texture_V.Get(), &srvDesc, srvHandleCpu);
-        }
+        // V plane
+        srvDesc.Format = frameToDraw.hw_decoded_texture_V->GetDesc().Format;
+        g_d3d12Device->CreateShaderResourceView(
+            frameToDraw.hw_decoded_texture_V.Get(), &srvDesc, srvHandleCpu);
 
         // シェーダ可視ヒープ設定（従来通り）
         ID3D12DescriptorHeap* ppHeaps[] = { g_srvHeap.Get() };
@@ -2235,7 +2212,6 @@ g_copyFence.Reset();
     if (g_srvHeap) g_srvHeap.Reset();
     if (g_vertexBuffer) g_vertexBuffer.Reset();
     if (g_pipelineStateYuv444) g_pipelineStateYuv444.Reset();
-    if (g_pipelineStateNv12) g_pipelineStateNv12.Reset();
     if (g_rootSignature) g_rootSignature.Reset();
     if (g_d3d12Device) g_d3d12Device.Reset();
 


### PR DESCRIPTION
## Summary
- drop NV12 plane layout detection and fail decoder creation for non-YUV444 HEVC streams
- simplify NVDEC frame buffer allocation and copy logic to assume YUV444 outputs only
- remove NV12-specific rendering resources so the D3D12 pipeline always uses the YUV444 shader

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d61656b12c8321abb5fbe2b6d8a287