### PR TITLE
Handle NVDEC surface count increases from long GOP streams

### DIFF
--- a/nvdec.h
+++ b/nvdec.h
@@ -62,7 +62,7 @@ private:
     void copyDecodedFrameToD3D12(CUVIDPARSERDISPINFO* pDispInfo);
     void releaseDecoderResources();
     bool reconfigureDecoder(CUVIDEOFORMAT* pVideoFormat);
-    uint32_t determineDecodeSurfaceCount(const CUVIDEOFORMAT* pVideoFormat) const;
+    uint32_t determineDecodeSurfaceCount(const CUVIDEOFORMAT* pVideoFormat, bool logDecision = true) const;
 
     CUcontext m_cuContext;
     ID3D12Device* m_pD3D12Device;


### PR DESCRIPTION
## Summary
- re-evaluate NVDEC surface requirements on sequence callbacks and recreate the decoder when the server requests more surfaces (e.g. longer GOPs)
- allow the surface count helper to skip verbose logging when used for internal checks

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da800cf80c83218db4c75cd52acd1d